### PR TITLE
도와주세요 게시판 스크롤 복구

### DIFF
--- a/src/components/organisms/help-board/HelpBoardCardList.tsx
+++ b/src/components/organisms/help-board/HelpBoardCardList.tsx
@@ -14,7 +14,6 @@ const HelpBoardCardList = () => {
   const [load, setLoad] = useState(false);
   const preventRef = useRef(true); //옵저버 중복 방지
   const router = useRouter();
-  const [isScroll, setScroll] = useState(false);
 
   //옵저버 생성
   useEffect(() => {
@@ -33,7 +32,6 @@ const HelpBoardCardList = () => {
   //무한스크롤 로드
   useEffect(() => {
     loadPost();
-    setScroll(true);
   }, [totalPage]);
 
   const handleObs = (entries: any) => {

--- a/src/components/organisms/help-board/HelpBoardCardList.tsx
+++ b/src/components/organisms/help-board/HelpBoardCardList.tsx
@@ -14,7 +14,7 @@ const HelpBoardCardList = () => {
   const [load, setLoad] = useState(false);
   const preventRef = useRef(true); //옵저버 중복 방지
   const router = useRouter();
-  const [listBack, setListBack] = useState(0);
+  const [isScroll, setScroll] = useState(false);
 
   //옵저버 생성
   useEffect(() => {
@@ -33,6 +33,7 @@ const HelpBoardCardList = () => {
   //무한스크롤 로드
   useEffect(() => {
     loadPost();
+    setScroll(true);
   }, [totalPage]);
 
   const handleObs = (entries: any) => {
@@ -92,11 +93,9 @@ const HelpBoardCardList = () => {
     const temp = JSON.parse(
       sessionStorage.getItem(`__next_scroll_back`) as string,
     );
-    // temp && setListBack(Number(temp.y));
     temp && setTimeout(() => window.scrollTo(0, temp.y), 0);
-    // temp && window.scrollTo(0, Number(temp.y));
-    window.sessionStorage.clear();
-  }, []);
+    // window.sessionStorage.clear();
+  }, [getList]);
 
   return (
     <S.HelpCardContainer>


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
도와주세요 게시판 스크롤 내용 복구
기존에 ```[]``` -> ```[getList]``` ```useEffect``` 종속성 변경
CSR방식을 사용하기 때문에 문서의 내용을 먼저 불러오고, 이후 스크롤에 대한 정보를 로드 시켜서 작동시키는 방식으로 수정

이 후 리펙토링 과정에서 SSR방식으로 변경해서 깜빡이는 부분 수정 예정
완전히 페이지를 나갔을 때 session의 내용을 없애야 하는 로직 추가 예정