### PR TITLE
새로고침시에도 로드

### DIFF
--- a/src/components/organisms/help-board/HelpBoardCardList.tsx
+++ b/src/components/organisms/help-board/HelpBoardCardList.tsx
@@ -81,8 +81,10 @@ const HelpBoardCardList = () => {
   //   router발생시 스크롤 위치 저장
   useEffect(() => {
     router.events.on('routeChangeStart', handleRouteChange);
+    window.addEventListener('beforeunload', handleRouteChange);
     return () => {
       router.events.off('routeChangeStart', handleRouteChange);
+      window.removeEventListener('beforeunload', handleRouteChange);
     };
   }, [router.events]);
 


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
원래는 페이지가 넘어가면 ```session```을 ```clear```하는 로직이었는데, 어짜피 ```session```은 브라우져의 정보를 가나는 순간 없애버리기 때문에 상관없다고 판단, window의 beforeunload 이벤트를 사용해서 새로고침시에도 해당 위치가 저장되도록 구현

p.s. 브랜치 잘못 설정했습니다. 봐주세요...ㅜㅜ
<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link
[참고사이트](https://liebe97.tistory.com/38)
