### PR TITLE
멘토유닛퍼블리싱(중단)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,10 @@ const nextConfig = {
   },
   images: {
     domains: ['menbosha-s3.s3.ap-northeast-2.amazonaws.com'],
+    domains: ['lh3.googleusercontent.com'],
+    domains: ['k.kakaocdn.net'],
+    domains: ['ssl.pstatic.net'],
+    domains: ['phinf.pstatic.net'],
   },
   reactStrictMode: true,
   eslint: {

--- a/src/apis/mentor.ts
+++ b/src/apis/mentor.ts
@@ -5,6 +5,7 @@ import {
 } from '@/types/mentor';
 import { AxiosResponse } from 'axios';
 import instance from './axiosInstance';
+import Category from '@/components/common/category/Category';
 
 const MENTOR = {
   path: `/mentor-board`,
@@ -26,8 +27,13 @@ const MENTOR = {
     return result.data;
   },
   /**멘토 게시판 페이지 불러오는 api [get] */
-  async getMentorBoardPage(): Promise<any> {
-    const result: AxiosResponse = await instance.get(`${MENTOR.path}/page`);
+  async getMentorBoardPage(category: number): Promise<any> {
+    const result: AxiosResponse = await instance.get(`${MENTOR.path}/page`, {
+      params: {
+        categoryId: category,
+      },
+    });
+    console.log(result);
     return result.data;
   },
 
@@ -38,10 +44,11 @@ const MENTOR = {
   ): Promise<MentorBoardListType[]> {
     const result: AxiosResponse = await instance.get(`${MENTOR.path}`, {
       params: {
-        category: category,
+        categoryId: category,
         page: page,
       },
     });
+    console.log(result);
     return result.data.data;
   },
 

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -30,7 +30,7 @@ const USER = {
         userId: id,
       },
     });
-    return result.data.data;
+    return result.data;
   },
 };
 

--- a/src/components/molecules/mentor-board-unit-elements/MentorBoardUnitBottom.tsx
+++ b/src/components/molecules/mentor-board-unit-elements/MentorBoardUnitBottom.tsx
@@ -1,5 +1,39 @@
-const MentorBoardUnitBottom = () => {
-  return <div>바텀</div>;
+import USER from '@/apis/user';
+import { FlexBox, ImageBox } from '@/components/common/globalStyled/styled';
+import { MentorBoardUnitPropsType } from '@/types/mentor';
+import { MentorType } from '@/types/user';
+import Image from 'next/image';
+import { useEffect, useState } from 'react';
+
+const MentorBoardUnitBottom = (props: MentorBoardUnitPropsType) => {
+  const [userInfo, setUserInfo] = useState<any>();
+
+  const getUserInfoApi = async () => {
+    const response = await USER.getUserInfo(props.id);
+    setUserInfo(response);
+  };
+
+  console.log(userInfo);
+
+  useEffect(() => {
+    getUserInfoApi();
+  }, []);
+  return (
+    <FlexBox type="flex">
+      <div>
+        <Image
+          src={userInfo?.image as string}
+          alt="33"
+          width={232}
+          height={232}
+        />
+        <div>
+          <div>랭크</div>
+          <div>이름</div>
+        </div>
+      </div>
+    </FlexBox>
+  );
 };
 
 export default MentorBoardUnitBottom;

--- a/src/components/molecules/mentor-board-unit-elements/MentorBoardUnitHead.tsx
+++ b/src/components/molecules/mentor-board-unit-elements/MentorBoardUnitHead.tsx
@@ -1,21 +1,54 @@
-import { FlexBox, ImageBox } from '@/components/common/globalStyled/styled';
+import {
+  FlexBox,
+  ImageBox,
+  TextBox,
+} from '@/components/common/globalStyled/styled';
 import { MBUnitHeadPropsType } from '@/types/mentor';
+import Image from 'next/image';
+import * as S from './style';
+import { useRouter } from 'next/router';
 
 const MentorBoardUnitHead = (props: MBUnitHeadPropsType) => {
+  const router = useRouter();
+
+  const modifiedMentorBoardUnit = () => {
+    //경로 추가 예정
+    router.push(
+      {
+        pathname: ``,
+        query: {
+          head: props.head,
+          body: props.body,
+          image: props.image,
+        },
+      },
+      ``,
+    );
+  };
   return (
     <div>
-      <div>{props.head}</div>
+      <TextBox color="#FF4651" size={40}>
+        {props.head}
+      </TextBox>
       <FlexBox type="flex">
-        <ImageBox src={props.userImage} />
-        <div>
-          <div>{props.userName}</div>
-          <div>{props.category}</div>
-          <div>{props.createdAt.slice(0, 10)}</div>
-          <div>
-            <div>수정버튼</div>
-            <div>삭제버튼</div>
-          </div>
-        </div>
+        <Image
+          src={props.userImage}
+          alt="프로필이미지"
+          width={53}
+          height={53}
+          style={{ borderRadius: 10 }}
+        />
+        <S.HeadProfile>
+          <TextBox size={16}>{props.userName}</TextBox>
+          <FlexBox type="flex">
+            <TextBox size={12}>{props.category}</TextBox>
+            <TextBox size={10}>{props.createdAt.slice(0, 10)}</TextBox>
+          </FlexBox>
+        </S.HeadProfile>
+        <FlexBox type="flex" style={{ margin: '0px 0px 0px auto' }}>
+          <div onClick={modifiedMentorBoardUnit}>수정버튼</div>
+          <div>삭제버튼</div>
+        </FlexBox>
       </FlexBox>
     </div>
   );

--- a/src/components/molecules/mentor-board-unit-elements/style.ts
+++ b/src/components/molecules/mentor-board-unit-elements/style.ts
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+export const HeadProfile = styled.div`
+  > :nth-child(1) {
+    padding: 0px 0px 3px 12px;
+  }
+  > :nth-child(2) {
+    width: 140px;
+    justify-content: space-evenly;
+  }
+`;

--- a/src/components/organisms/mentor-board/MentorBoardList.tsx
+++ b/src/components/organisms/mentor-board/MentorBoardList.tsx
@@ -42,9 +42,8 @@ const MentorBoardList = () => {
   };
   //페이지 수 로드 함수
   const getPage = useCallback(async () => {
-    // const response = await MENTOR.getMentorBoardPage();
-    // setTotalPage(response.totalPage);
-    setTotalPage(1);
+    const response = await MENTOR.getMentorBoardPage(5);
+    setTotalPage(response.totalPage);
   }, []);
 
   //스크롤 시 로드 함수
@@ -52,7 +51,7 @@ const MentorBoardList = () => {
     setLoad(true); //로딩 시작
     if (totalPage > 0) {
       //나중에 카테고리 전역으로 관리 예정
-      const result = await MENTOR.getMentorBoardList(1, totalPage); //api요청 글 목록 불러오기
+      const result = await MENTOR.getMentorBoardList(5, totalPage); //api요청 글 목록 불러오기
       const reverseArr = [...result].reverse();
       result && setBoardData((prev: any) => [...prev, ...reverseArr]);
     }
@@ -104,7 +103,7 @@ const MentorBoardList = () => {
           id: data.id,
           head: data.head,
           body: data.body,
-          category: data.category,
+          category: data.categoryId,
           createdAt: data.createdAt,
           updatedAt: data.updatedAt,
           userId: data.user.userImage.userId,

--- a/src/components/organisms/mentor-board/MentorBoardUnit.tsx
+++ b/src/components/organisms/mentor-board/MentorBoardUnit.tsx
@@ -6,6 +6,7 @@ import {
   ImageBox,
 } from '@/components/common/globalStyled/styled';
 import MentorBoardUnitBody from '@/components/molecules/mentor-board-unit-elements/MentorBoardUnitBody';
+import MentorBoardUnitBottom from '@/components/molecules/mentor-board-unit-elements/MentorBoardUnitBottom';
 import MentorBoardUnitHead from '@/components/molecules/mentor-board-unit-elements/MentorBoardUnitHead';
 import { MentorBoardUnitPropsType, MentorBoardUnitType } from '@/types/mentor';
 import Image from 'next/image';
@@ -22,6 +23,8 @@ const MentorBoardUnit = ({ id }: MentorBoardUnitPropsType) => {
     setUnitData(response);
   };
 
+  console.log(getUnitData);
+
   useEffect(() => {
     getMentorBoardUnitApi();
   }, []);
@@ -32,24 +35,18 @@ const MentorBoardUnit = ({ id }: MentorBoardUnitPropsType) => {
         <div>
           <MentorBoardUnitHead
             head={getUnitData.head}
+            body={getUnitData.body}
+            image={getUnitData.mentorBoardImages}
             userImage={getUnitData.user.userImage.imageUrl}
             userName={getUnitData.user.name}
             category={category as string}
             createdAt={getUnitData.createdAt}
           />
           <MentorBoardUnitBody
-            image={getUnitData.image}
+            image={getUnitData.mentorBoardImages}
             body={getUnitData.body}
           />
-          <FlexBox type="flex">
-            <div>
-              <ImageBox src={getUnitData?.user.userImage.imageUrl as string} />
-              <div>
-                <div>랭크</div>
-                <div>이름</div>
-              </div>
-            </div>
-          </FlexBox>
+          <MentorBoardUnitBottom id={getUnitData.user.userImage.userId} />
         </div>
       )}
     </div>

--- a/src/components/organisms/mentor-board/MentorBoardUnit.tsx
+++ b/src/components/organisms/mentor-board/MentorBoardUnit.tsx
@@ -23,8 +23,6 @@ const MentorBoardUnit = ({ id }: MentorBoardUnitPropsType) => {
     setUnitData(response);
   };
 
-  console.log(getUnitData);
-
   useEffect(() => {
     getMentorBoardUnitApi();
   }, []);

--- a/src/components/templates/mentor-template/MentorUnitTemplate.tsx
+++ b/src/components/templates/mentor-template/MentorUnitTemplate.tsx
@@ -1,0 +1,5 @@
+const MentorUnitTemplate = () => {
+  return <div>멘토유닛템플릿</div>;
+};
+
+export default MentorUnitTemplate;

--- a/src/hooks/useCarousel.tsx
+++ b/src/hooks/useCarousel.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useRef, useState } from 'react';
+
+const useCarousel = (image: any) => {
+  const [currentSlide, setCurrentSlide] = useState<number>(0);
+  const slideRef = useRef<HTMLDivElement>(null);
+
+  const handleSlideNext = () => {
+    if (currentSlide === image.length - 1) {
+      setCurrentSlide(0);
+      // alert('마지막 사진 입니다.');
+    } else {
+      setCurrentSlide(currentSlide + 1);
+    }
+  };
+
+  const handleSlidePrev = () => {
+    if (currentSlide === 0) {
+      setCurrentSlide(image.length - 1);
+      // alert('맨 앞 사진 입니다.');
+    } else {
+      setCurrentSlide(currentSlide - 1);
+    }
+  };
+
+  useEffect(() => {
+    if (slideRef.current !== null) {
+      slideRef.current.style.transition = 'all 0.5s ease-in-out';
+      slideRef.current.style.transform = `translateX(-${currentSlide}00%)`;
+    }
+  }, [currentSlide]);
+
+  return [slideRef, handleSlidePrev, handleSlideNext];
+};
+
+export default useCarousel;

--- a/src/pages/mentor/unit/[id].tsx
+++ b/src/pages/mentor/unit/[id].tsx
@@ -1,0 +1,11 @@
+import MentorUnitTemplate from '@/components/templates/mentor-template/MentorUnitTemplate';
+
+const MentorUnit = () => {
+  return (
+    <div>
+      <MentorUnitTemplate />
+    </div>
+  );
+};
+
+export default MentorUnit;

--- a/src/types/mentor.d.ts
+++ b/src/types/mentor.d.ts
@@ -12,7 +12,7 @@ export type MentorBoardListType = {
   id: number;
   head: string;
   body: string;
-  category: number;
+  categoryId: number;
   createdAt: string;
   updatedAt: string;
   user: {
@@ -51,7 +51,7 @@ export type MentorBoardUnitType = {
   createdAt: string;
   updatedAt: string;
   categoryId: number;
-  image: Array;
+  mentorBoardImages: Array;
   user: {
     name: string;
     userImage: {
@@ -71,6 +71,8 @@ export interface MentorBoardUnitPropsType {
 /**멘토 게시글 중 Head Props Type */
 export interface MBUnitHeadPropsType {
   head: string;
+  body: string;
+  image: Array;
   userName: string;
   userImage: string;
   category: string;
@@ -80,10 +82,4 @@ export interface MBUnitHeadPropsType {
 export interface MBUnitBodyPropsType {
   image: Array;
   body: string;
-}
-
-/**멘토 게시글 중 Bottom Props Type */
-export interface MBUnitBottomPropsType {
-  id: number;
-  userImage;
 }


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
기존에 멘토 유닛과 멘토 게시글 유닛의 퍼블리싱을 진행하려고 했는데, api와 데이터의 구성을 모두 끝내고 나서 퍼블리싱을 진행하는게 좋겠다고 판단해서 중단했습니다.

<!-- 추가예정 내용 (있다면 필수)-->
### Schedule
현재 작업중인 내용을 중단하고,
- 멘토 게시글 추가 기능 구현 (api연동)
- 멘토 게시글 수정 기능 구현 (api연동)
- 멘토 게시글 삭제 기능 구현 (api연동)

<!-- 추가된 전역관리 내용 (있다면 필수) -->
### Global Style, Recoil, Hook
useCarousel
```jsx
const [ slideRef, handleSlidePrev, handleSlidNext ] = useCarousel(image);
```
ref위치를 지정할 수 있는 값을 받아오고, 이전과, 이후로 갈 수 있는 함수로 구성
매개변수로 image의 배열형태를 전달해 줘야합니다.

추가로 작동아 안될 수 있습니다. 테스트는 위에 기능구현 끝나고 진행하겠습니다.
