### PR TITLE
feat(#86):카테고리 리스트 기능추가

### DIFF
--- a/src/apis/help.ts
+++ b/src/apis/help.ts
@@ -56,11 +56,10 @@ const HELP = {
   ): Promise<HelpListApiType> {
     const result: AxiosResponse = await instance.get(`${HELP.path}`, {
       params: {
-        category: category,
+        category: category !== 1 ? category : '',
         page: page,
       },
     });
-    console.log(result);
     return result.data;
   },
 

--- a/src/components/common/category/Category.tsx
+++ b/src/components/common/category/Category.tsx
@@ -1,45 +1,53 @@
-import styled from 'styled-components';
+import { categoryList } from './categoryList';
+import React, { useEffect, useState } from 'react';
+import * as S from './styled';
+import { useRecoilState } from 'recoil';
+import { CategoryFilterAtom } from '@/recoil/atoms/CategorySelectAtom';
+
+export interface filterType {
+  id: number;
+  category: string;
+}
 
 const Category = () => {
+  const [catNum, setCatNum] = useRecoilState(CategoryFilterAtom);
+  const [filterList, setFilterList] = useState<filterType[]>([]);
+
+  useEffect(() => {
+    const temp = categoryList.filter((data) => data.id !== 1);
+    setFilterList(temp);
+  }, []);
+
+  const handleCategory = (e: any) => {
+    const value = e.target.innerHTML;
+    const temp = categoryList.find((data) => data.category === value)?.id;
+    temp && setCatNum(temp);
+    if (temp === catNum) {
+      setCatNum(0);
+    }
+  };
+
   return (
-    <CategoryWrapper>
-      <CategoryContainer>
-        <CategoryBox>카테고리</CategoryBox>
-        <CategoryBox>카테고리2123123</CategoryBox>
-        <CategoryBox>카테고리3</CategoryBox>
-        <CategoryBox>카테고리4</CategoryBox>
-      </CategoryContainer>
-    </CategoryWrapper>
+    <S.CategoryWrapper>
+      <S.CategoryContainer>
+        {filterList.map((data) => {
+          return (
+            <div>
+              {catNum === data.id ? (
+                <S.CategoryBox isCat={true} onClick={handleCategory}>
+                  {data.category}
+                </S.CategoryBox>
+              ) : (
+                <S.CategoryBox isCat={false} onClick={handleCategory}>
+                  {data.category}
+                </S.CategoryBox>
+              )}
+            </div>
+          );
+        })}
+      </S.CategoryContainer>
+    </S.CategoryWrapper>
   );
 };
 
 export default Category;
-
-const CategoryWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  margin: 40px 0px 25px 0px;
-`;
-
-const CategoryContainer = styled.div`
-  display: flex;
-  justify-content: left;
-  min-width: 500px;
-  width: 1532px;
-`;
-
-const CategoryBox = styled.div`
-  padding: 7px;
-  border: 1px solid #ff772b;
-  border-radius: 10px;
-  color: #000;
-  width: auto;
-  margin: 6px;
-  font-size: 16px;
-  cursor: pointer;
-  transition: all 300ms ease;
-  &:hover {
-    background-color: #c63d2f;
-    transition: all 300ms ease;
-  }
-`;

--- a/src/components/common/category/categoryList.ts
+++ b/src/components/common/category/categoryList.ts
@@ -1,50 +1,54 @@
 export const categoryList = [
   {
     id: 1,
-    category: 'IT',
+    category: '전체',
   },
   {
     id: 2,
-    category: '요리',
+    category: 'IT',
   },
   {
     id: 3,
-    category: '디자인',
+    category: '요리',
   },
   {
     id: 4,
-    category: '운동',
+    category: '디자인',
   },
   {
     id: 5,
-    category: '패션/뷰티',
+    category: '운동',
   },
   {
     id: 6,
-    category: '투자',
+    category: '패션/뷰티',
   },
   {
     id: 7,
-    category: '게임',
+    category: '투자',
   },
   {
     id: 8,
-    category: '음악',
+    category: '게임',
   },
   {
     id: 9,
-    category: '반려동물',
+    category: '음악',
   },
   {
     id: 10,
-    category: '회화',
+    category: '반려동물',
   },
   {
     id: 11,
-    category: '육아',
+    category: '회화',
   },
   {
     id: 12,
+    category: '육아',
+  },
+  {
+    id: 13,
     category: '공부',
   },
 ];

--- a/src/components/common/category/styled.ts
+++ b/src/components/common/category/styled.ts
@@ -1,0 +1,35 @@
+import styled from 'styled-components';
+
+export const CategoryWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  margin: 40px 0px 25px 0px;
+`;
+
+export const CategoryContainer = styled.div`
+  display: flex;
+  justify-content: left;
+  min-width: 500px;
+  width: 1532px;
+`;
+
+interface IsCategoryType {
+  isCat?: boolean;
+}
+
+export const CategoryBox = styled.div<IsCategoryType>`
+  padding: 7px;
+  border: 2px solid #ff772b;
+  border-radius: 10px;
+  color: #000;
+  width: auto;
+  background-color: ${({ isCat }) => (isCat ? '#c63d2f' : '#fff')};
+  margin: 6px;
+  font-size: 16px;
+  cursor: pointer;
+  transition: all 300ms ease;
+  &:hover {
+    border: 2px solid #c63d2f;
+    transition: all 300ms ease;
+  }
+`;

--- a/src/components/molecules/create-board-elements/CategorySelector.tsx
+++ b/src/components/molecules/create-board-elements/CategorySelector.tsx
@@ -5,11 +5,13 @@ import useModal from '@/hooks/useModal';
 import { categoryList } from '../../common/category/categoryList';
 import { CategorySelectAtom } from '@/recoil/atoms/CategorySelectAtom';
 import { useRouter } from 'next/router';
+import { filterType } from '@/components/common/category/Category';
 
 const CategorySelectorBox = () => {
   const [getCategory, setCategory] = useRecoilState(CategorySelectAtom);
   const resetSelect = useResetRecoilState(CategorySelectAtom);
   const { isOpenModal, handleModal } = useModal();
+  const [getFilterCategory, setFilterCategory] = useState<filterType[]>([]);
   const router = useRouter();
 
   /** 게시판 선택 시 */
@@ -20,6 +22,8 @@ const CategorySelectorBox = () => {
 
   //다른 페이지로 넘어가도 select초기화
   useEffect(() => {
+    const temp = categoryList.filter((data) => data.id !== 1);
+    setFilterCategory(temp);
     router.events.on('routeChangeStart', resetSelect);
     return () => {
       router.events.off('routeChangeStart', resetSelect);
@@ -31,7 +35,7 @@ const CategorySelectorBox = () => {
       <SelectBox onClick={handleModal}>
         <Label>{getCategory ? getCategory : '카테고리'}</Label>
         <SelectOptions show={`${isOpenModal}`}>
-          {categoryList.map((list) => {
+          {getFilterCategory.map((list) => {
             return (
               <div key={list.id}>
                 <Option onClick={handleOnChangeSelectValue}>

--- a/src/components/molecules/help-board-elements/HelpCard.tsx
+++ b/src/components/molecules/help-board-elements/HelpCard.tsx
@@ -12,6 +12,8 @@ const HelpCard = (props: HelpListType) => {
   useEffect(() => {
     setStateHtml(true);
   }, []);
+
+  console.log(props.createdAt);
   return (
     <S.CardLink
       href={{
@@ -40,7 +42,7 @@ const HelpCard = (props: HelpListType) => {
           size={14}
           color="#000"
           style={{ padding: '10px 0px 10px 0px' }}>
-          {props.createdAt.slice(0, 10)}
+          {props.createdAt && props.createdAt.slice(0, 10)}
         </TextBox>
       </S.CardContainer>
     </S.CardLink>

--- a/src/components/organisms/help-board/HelpBoardCardList.tsx
+++ b/src/components/organisms/help-board/HelpBoardCardList.tsx
@@ -6,6 +6,8 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import * as S from './styled';
 import { HelpListApiType } from '@/types/help';
 import { useRouter } from 'next/router';
+import { useRecoilState } from 'recoil';
+import { CategoryFilterAtom } from '@/recoil/atoms/CategorySelectAtom';
 
 const HelpBoardCardList = () => {
   const [totalPage, setTotalPage] = useState(0); //페이지 수
@@ -14,6 +16,8 @@ const HelpBoardCardList = () => {
   const [load, setLoad] = useState(false);
   const preventRef = useRef(true); //옵저버 중복 방지
   const router = useRouter();
+  const [filterCategory, setFilterCategory] =
+    useRecoilState(CategoryFilterAtom);
 
   //옵저버 생성
   useEffect(() => {
@@ -24,9 +28,16 @@ const HelpBoardCardList = () => {
     };
   }, [obsRef, getList]);
 
-  //첫 페이지 로드
   useEffect(() => {
+    //첫 페이지 로드
     getLoadPage();
+    // 스크롤 수동으로 조정 설정
+    if (
+      'scrollRestoration' in history &&
+      history.scrollRestoration !== 'manual'
+    ) {
+      history.scrollRestoration = 'manual';
+    }
   }, []);
 
   //무한스크롤 로드
@@ -52,21 +63,12 @@ const HelpBoardCardList = () => {
   const loadPost = useCallback(async () => {
     setLoad(true); //로딩 시작
     if (totalPage > 0) {
-      const result = await HELP.getHelpBoardList(5, totalPage); //api요청 글 목록 불러오기
+      const result = await HELP.getHelpBoardList(filterCategory, totalPage); //api요청 글 목록 불러오기
       const reverseArr = [...result.data].reverse();
       result && setGetList((prev: any) => [...prev, ...reverseArr]);
     }
     setLoad(false);
   }, [totalPage]);
-  // 스크롤 수동으로 조정 설정
-  useEffect(() => {
-    if (
-      'scrollRestoration' in history &&
-      history.scrollRestoration !== 'manual'
-    ) {
-      history.scrollRestoration = 'manual';
-    }
-  }, []);
 
   const handleRouteChange = (e: any) => {
     sessionStorage.setItem(

--- a/src/components/organisms/help-board/HelpPullingBoardList.tsx
+++ b/src/components/organisms/help-board/HelpPullingBoardList.tsx
@@ -17,6 +17,8 @@ const HelpPullingBoardList = () => {
     getPullingUpApi();
   }, []);
 
+  console.log(getPullingData);
+
   return (
     <S.HelpCardContainer>
       {getPullingData.map((data: any) => {

--- a/src/components/organisms/help-board/HelpPullingBoardList.tsx
+++ b/src/components/organisms/help-board/HelpPullingBoardList.tsx
@@ -17,8 +17,6 @@ const HelpPullingBoardList = () => {
     getPullingUpApi();
   }, []);
 
-  console.log(getPullingData);
-
   return (
     <S.HelpCardContainer>
       {getPullingData.map((data: any) => {

--- a/src/recoil/atoms/CategorySelectAtom.ts
+++ b/src/recoil/atoms/CategorySelectAtom.ts
@@ -1,5 +1,7 @@
-import { atom } from 'recoil';
+import { RecoilEnv, atom } from 'recoil';
 import { recoilPersist } from 'recoil-persist';
+
+RecoilEnv.RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED = false;
 
 export const CategorySelectAtom = atom({
   key: 'categorySelect',
@@ -9,4 +11,9 @@ export const CategorySelectAtom = atom({
 export const SectionSelectAtom = atom({
   key: 'sectionSelect',
   default: '',
+});
+
+export const CategoryFilterAtom = atom({
+  key: 'catFilter',
+  default: 1,
 });

--- a/src/recoil/atoms/LoginStateAtom.ts
+++ b/src/recoil/atoms/LoginStateAtom.ts
@@ -1,7 +1,9 @@
-import { atom } from 'recoil';
+import { RecoilEnv, atom } from 'recoil';
 import { recoilPersist } from 'recoil-persist';
 
 const { persistAtom } = recoilPersist();
+
+RecoilEnv.RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED = false;
 
 export const LoginStateAtom = atom({
   key: 'loginState',

--- a/src/recoil/atoms/MentorInfoAtom.ts
+++ b/src/recoil/atoms/MentorInfoAtom.ts
@@ -1,5 +1,6 @@
 import { MentorInfoType } from '@/types/chat';
-import { atom } from 'recoil';
+import { RecoilEnv, atom } from 'recoil';
+RecoilEnv.RECOIL_DUPLICATE_ATOM_KEY_CHECKING_ENABLED = false;
 
 export const MentorInfoAtom = atom<MentorInfoType[]>({
   key: 'mentorInfo',


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
도와주세요, 멘토 게시판에서 카테고리를 누르면, 해당 카테고리에 대한 ```number```값이 저장되는 로직을 만들었습니다. 
해당 로직을 활용해서, 도와주세요, 멘토 게시판에서 글을 가지고오는 필터 기능을 구현합니다.

```recoil key값```에 대한 오류가 계속떠서 오류 메시지 삭제를 위한 코드를 작성했습니다.
노션에 ```.env```파일 업데이트 해 놨습니다. 나중에 백엔드에 추가 요청하겠습니다.

<!-- 추가예정 내용 (있다면 필수)-->
### Schedule
필터 기능 구현 예정

<!-- 추가된 전역관리 내용 (있다면 필수) -->
### Global Style, Recoil, Hook
```
CategoryFilterAtom : {
 key : 'catFilter'
 default : 1,
```
카테고리의 아이디 값을 관리하기 위한 recoil입니다.