### PR TITLE
feat(#80): 채팅방 삭제 및 타입 값 수정

### DIFF
--- a/src/components/molecules/chat-list-area/chat-list-box/ChatListBox.tsx
+++ b/src/components/molecules/chat-list-area/chat-list-box/ChatListBox.tsx
@@ -66,7 +66,14 @@ const ChatRoomListBox = () => {
       })}
       {isOpenModal && (
         <div>
-          <ChatRoomOutModal show={isOpenModal} hide={handleModal} />
+          {getChatRoomList.map((data) => (
+            <ChatRoomOutModal
+              show={isOpenModal}
+              hide={handleModal}
+              chatRoomId={data.chatRooms._id}
+              partnerName={data.chatPartner[0].name}
+            />
+          ))}
         </div>
       )}
     </S.ListContainer>

--- a/src/components/molecules/chat-list-area/chat-list-box/ChatRoomOutModal.tsx
+++ b/src/components/molecules/chat-list-area/chat-list-box/ChatRoomOutModal.tsx
@@ -1,17 +1,45 @@
 import { ModalType } from '@/types/chat';
 import styled from 'styled-components';
 import React from 'react';
+import CHAT from '@/apis/chatApi/chat';
+import { useRecoilState } from 'recoil';
+import { ChatRoomListAtom } from '@/recoil/atoms/ChatRoomListAtom';
 
-const ChatRoomOutModal = ({ show, hide }: ModalType) => {
+const ChatRoomOutModal = ({
+  show,
+  hide,
+  chatRoomId,
+  partnerName,
+}: ModalType) => {
+  const [chatRoomList, setChatRoomList] = useRecoilState(ChatRoomListAtom);
+
+  // 채팅방 나가기 기능
+  const handleChatRoomOut = async () => {
+    await CHAT.deleteChatRoom(chatRoomId);
+    updateChatRoomListApi();
+    handleCloseModal();
+  };
+
+  const updateChatRoomListApi = async () => {
+    const res = await CHAT.getChatRoomList();
+    setChatRoomList(res.chatRooms);
+  };
+
+  const handleCloseModal = () => {
+    if (show) {
+      hide();
+    }
+  };
+
   return (
-    <div style={{ zIndex: '1000', marginBottom: '100px' }}>
+    <div>
       <ModalWrapper>
         <ModalContainer>
           <ModalTitle>채팅방 나가기</ModalTitle>
           <span>님과의 채팅방을 나가시겠습니까?</span>
           <ButtonArea>
-            <button>예</button>
-            <button>아니오</button>
+            <button onClick={handleChatRoomOut}>예</button>
+            <button onClick={handleCloseModal}>아니오</button>
           </ButtonArea>
         </ModalContainer>
       </ModalWrapper>

--- a/src/components/molecules/chat-list-area/mentor-list-box/MentorListBox.tsx
+++ b/src/components/molecules/chat-list-area/mentor-list-box/MentorListBox.tsx
@@ -8,6 +8,8 @@ import { useRecoilState } from 'recoil';
 import Link from 'next/link';
 import useChatRoomCreate from '@/hooks/useCreateRoom';
 import { handleChatIconClickType } from '@/types/chat';
+import { ChatRoomListAtom } from '@/recoil/atoms/ChatRoomListAtom';
+import CHAT from '@/apis/chatApi/chat';
 
 const MentorListBox = () => {
   const [getMentorList, setGetMentorList] =
@@ -20,6 +22,7 @@ const MentorListBox = () => {
   const obsRef = useRef<HTMLDivElement>(null); // 옵저버 state
   const preventRef = useRef(true); // 옵저버 중복 방지
   const { handleCreateChatRoom, isLoading, error } = useChatRoomCreate();
+  const [chatRoomList, setChatRoomList] = useRecoilState(ChatRoomListAtom);
 
   // 옵저버 생성
   useEffect(() => {
@@ -88,7 +91,13 @@ const MentorListBox = () => {
     );
     if (confirmed) {
       await handleCreateChatRoom(mentorId);
+      updateChatRoomListApi();
     }
+  };
+
+  const updateChatRoomListApi = async () => {
+    const res = await CHAT.getChatRoomList();
+    setChatRoomList(res.chatRooms);
   };
 
   return (

--- a/src/components/templates/ChatPageTemplate.tsx
+++ b/src/components/templates/ChatPageTemplate.tsx
@@ -12,7 +12,6 @@ import ChatMentorList from '../organisms/chat/chat-list/ChatMentorList';
 import { ChatRoomListAtom } from '@/recoil/atoms/ChatRoomListAtom';
 
 const ChatPageTemplate = () => {
-  const [renderState, setRenderState] = useState(false);
   const [getChatRoomList, setGetChatRoomList] =
     useRecoilState<ChatRoomListType[]>(ChatRoomListAtom);
 
@@ -24,7 +23,6 @@ const ChatPageTemplate = () => {
   const getChatRoomListApi = async () => {
     const res = await CHAT.getChatRoomList();
     setGetChatRoomList(res.chatRooms);
-    setRenderState(true);
   };
 
   /** 멘토리스트 전체조회 api (mock) */

--- a/src/types/chat.d.ts
+++ b/src/types/chat.d.ts
@@ -118,8 +118,10 @@ export interface ChatType {
   }[];
 }
 
-/** 채팅 페이지 모달 타입 */
+/** 채팅방 삭제 모달 타입 */
 export interface ModalType {
   show: boolean;
   hide: () => void;
+  chatRoomId: string;
+  partnerName: string;
 }


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
채팅방 삭제 기능 추가하였고, 생성과 삭제 시 리랜더링 없이 `useRecoilState`로 상태값 변경만을 통해서 UX 적인 부분 개선했습니다.
<!-- 추가예정 내용 (있다면 필수)-->
### Schedule
바로 채팅방(실제 채팅구역) 부분 페이지 라우팅 시작하겠습니다.
<!-- 추가된 전역관리 내용 (있다면 필수) -->
### Global Style, Recoil, Hook
_mentorInfoAtom_
```
export const MentorInfoAtom = atom<MentorInfoType[]>({
  key: 'mentorInfo',
  default: [],
});
```
_chatRoomListAtom 부활_
```
export const ChatRoomListAtom = atom({
  key: 'chatRoomList',
  default: [] as ChatRoomListType[],
});
```

_저번에 못 올린 `createChatRoomHook`_
```
return {
    handleCreateChatRoom,
    isLoading,
    error,
  };
```
1. handleCreateChatRoom으로 채팅룸 생성 API
2. isLoading으로 API 호출 시 true, 생성 완료 시 false
3. 비동기 처리중 발생한 error 전달 (API 선언부에서 try-catch로 에러를 잡고 있지 않으니)
사실상 isLoading과 error는 필요없긴 합니다 허허

추가로 노션에 정리 하겠습니다.