### PR TITLE
유저 정보 조회/수정 구현

### DIFF
--- a/src/apis/count.ts
+++ b/src/apis/count.ts
@@ -7,11 +7,11 @@ const COUNT = {
   async totalCount(
     action: 'increment' | 'decrement',
     type:
-      | 'countMentorBoard' //멘토 게시글 수
-      | 'countHelpYouComment' //도와주세요 댓글 수
-      | 'countMentorBoardLike' //멘토 게시글 좋아요 수
-      | 'countBadge' //멘토 뱃지 수
-      | 'countReview: ', //멘토 후기 수
+      | 'mentorBoardCount' //멘토 게시글 수
+      | 'helpYouCommentCount' //도와주세요 댓글 수
+      | 'mentorBoardLikeCount' //멘토 게시글 좋아요 수
+      | 'badgeCount' //멘토 뱃지 수
+      | 'reviewCount: ', //멘토 후기 수
     userId?: number,
   ): Promise<any> {
     const result: AxiosResponse = await instance.patch(

--- a/src/apis/helpComment.ts
+++ b/src/apis/helpComment.ts
@@ -9,7 +9,7 @@ const HELPCOMMENT = {
   /** 도와주세요 댓글 생성 api [post] */
   async createHelpComment(boardId: number): Promise<any> {
     try {
-      await COUNT.totalCount('increment', 'countHelpYouComment');
+      await COUNT.totalCount('increment', 'helpYouCommentCount');
       const result: AxiosResponse = await instance.post(
         `${HELPCOMMENT.path}`,
         {

--- a/src/apis/mentor.ts
+++ b/src/apis/mentor.ts
@@ -18,7 +18,7 @@ const MENTOR = {
     body,
     category,
   }: CreateMentorBoardType): Promise<any> {
-    await COUNT.totalCount('increment', 'countMentorBoard');
+    await COUNT.totalCount('increment', 'mentorBoardCount');
     const result: AxiosResponse = await instance.post<CreateMentorBoardType>(
       `${MENTOR.path}`,
       {
@@ -119,7 +119,7 @@ const MENTOR = {
 
   /**멘토 게시글 좋아요 생성 [post] */
   async createLike(boardId: number): Promise<any> {
-    await COUNT.totalCount('increment', 'countMentorBoardLike');
+    await COUNT.totalCount('increment', 'mentorBoardLikeCount');
     const result: AxiosResponse = await instance.post(
       `${MENTOR.path}/${boardId}/like`,
     );
@@ -128,7 +128,7 @@ const MENTOR = {
 
   /**멘토 게시글 좋아요 삭제 [delete] */
   async deleteLike(boardId: number): Promise<any> {
-    await COUNT.totalCount('decrement', 'countMentorBoardLike');
+    await COUNT.totalCount('decrement', 'mentorBoardLikeCount');
     const result: AxiosResponse = await instance.delete(
       `${MENTOR.path}/${boardId}/like`,
     );

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -1,6 +1,6 @@
-import { MentorType } from '@/types/user';
 import { AxiosResponse } from 'axios';
 import instance from './axiosInstance';
+import { UpdateProfileType } from '@/types/user';
 
 const USER = {
   path: '/user',
@@ -46,6 +46,25 @@ const USER = {
       `${USER.path}/total-ranking`,
     );
     return result.data.userRanking;
+  },
+
+  /**본인 정보 수정 api */
+  async updateMyProfile(update: UpdateProfileType): Promise<any> {
+    const result: AxiosResponse = await instance.patch(
+      `${USER.path}/my/intro`,
+      {
+        shortIntro: update.shortIntro,
+        career: update.career,
+        customCategory: update.customCategory,
+        detail: update.detail,
+        portfolio: update.portfolio,
+        sns: update.sns,
+        hopeCategory: update.hopeCategoryId,
+        activityCategory: update.activityCategoryId,
+        isMentor: update.isMentor,
+      },
+    );
+    return result;
   },
 };
 

--- a/src/components/organisms/my-profile/MyProfileConetents.tsx
+++ b/src/components/organisms/my-profile/MyProfileConetents.tsx
@@ -1,0 +1,76 @@
+import USER from '@/apis/user';
+import { FlexBox, ImageBox } from '@/components/common/globalStyled/styled';
+import { useEffect, useState } from 'react';
+import * as S from './styled';
+import { UserProfileType } from '@/types/user';
+import Link from 'next/link';
+
+const MyProfileContents = () => {
+  const [getInfo, setInfo] = useState<UserProfileType>();
+
+  const getMyInfoApi = async () => {
+    const response = await USER.getMyInfo();
+    setInfo(response);
+  };
+
+  useEffect(() => {
+    getMyInfoApi();
+  }, []);
+  return (
+    <div>
+      <S.ContentContainer>
+        <S.HeaderContentsBox>개인프로필</S.HeaderContentsBox>
+        <S.HeaderContentsBox>
+          <ImageBox
+            src={getInfo?.image}
+            width="280px"
+            height="350px"
+            size="contain"></ImageBox>
+          <FlexBox type="flex">
+            <div>
+              <div>{getInfo?.name}</div>
+              {getInfo?.isMentor ? <div>멘토</div> : <div>멘토아님</div>}
+            </div>
+            <div>{getInfo?.rank}</div>
+          </FlexBox>
+        </S.HeaderContentsBox>
+        <Link
+          href={{
+            pathname: `/mypage/info/update`,
+          }}>
+          설정
+        </Link>
+      </S.ContentContainer>
+      <S.ContentContainer>
+        <S.BodyContentsBox>
+          <div>소개</div>
+          <div>{getInfo?.intro.shortIntro}</div>
+        </S.BodyContentsBox>
+        <S.BodyContentsBox>
+          <div>주요경력</div>
+          <div>{getInfo?.intro.career}</div>
+        </S.BodyContentsBox>
+        <S.BodyContentsBox>
+          <div>관심카테고리</div>
+          <div>{getInfo?.intro.customCategory}</div>
+        </S.BodyContentsBox>
+      </S.ContentContainer>
+      <S.DetailBox>
+        <div>세부사항</div>
+        <div>{getInfo?.intro.detail}</div>
+      </S.DetailBox>
+      <S.ContentContainer>
+        <S.ShareBox>
+          <div>포트폴리오</div>
+          <div>{getInfo?.intro.portfolio}</div>
+        </S.ShareBox>
+        <S.ShareBox>
+          <div>SNS</div>
+          <div>{getInfo?.intro.sns}</div>
+        </S.ShareBox>
+      </S.ContentContainer>
+    </div>
+  );
+};
+
+export default MyProfileContents;

--- a/src/components/organisms/my-profile/UpdateMyProfile.tsx
+++ b/src/components/organisms/my-profile/UpdateMyProfile.tsx
@@ -1,0 +1,153 @@
+import USER from '@/apis/user';
+import { FlexBox, ImageBox } from '@/components/common/globalStyled/styled';
+import React, { useEffect, useState } from 'react';
+import * as S from './styled';
+import { useRouter } from 'next/router';
+
+const UpdateMyProfile = () => {
+  const router = useRouter();
+  const [updateInfo, setUpdateInfo] = useState({
+    name: '',
+    image: '',
+    isMentor: false,
+    hopeCategoryId: 0,
+    activityCategoryId: 0,
+    career: '',
+    customCategory: '',
+    detail: '',
+    portfolio: '',
+    shortIntro: '',
+    sns: '',
+    rank: 0,
+  });
+
+  const handleInputValue = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const name = e.target.name;
+    const value = e.target.value;
+    setUpdateInfo((prev) => {
+      return {
+        ...prev,
+        [name]: value,
+      };
+    });
+  };
+
+  const getMyInfoApi = async () => {
+    const response = await USER.getMyInfo();
+    setUpdateInfo(() => {
+      return {
+        name: response.name,
+        image: response.image,
+        isMentor: response.isMentor,
+        hopeCategoryId: response.hopeCategoryId,
+        activityCategoryId: response.activityCategoryId,
+        career: response.intro.career,
+        customCategory: response.intro.customCategory,
+        detail: response.intro.detail,
+        portfolio: response.intro.portfolio,
+        shortIntro: response.intro.shortIntro,
+        sns: response.intro.sns,
+        rank: response.rank,
+      };
+    });
+  };
+
+  const handleUpdateProfile = async () => {
+    const temp = {
+      isMentor: updateInfo.isMentor,
+      hopeCategoryId: updateInfo.hopeCategoryId,
+      activityCategoryId: updateInfo.activityCategoryId,
+      career: updateInfo.career,
+      customCategory: updateInfo.customCategory,
+      detail: updateInfo.detail,
+      portfolio: updateInfo.portfolio,
+      shortIntro: updateInfo.shortIntro,
+      sns: updateInfo.sns,
+    };
+    await USER.updateMyProfile(temp);
+    router.push('/mypage/info');
+  };
+
+  useEffect(() => {
+    getMyInfoApi();
+  }, []);
+  return (
+    <div>
+      <S.ContentContainer>
+        <S.HeaderContentsBox>개인프로필</S.HeaderContentsBox>
+        <S.HeaderContentsBox>
+          <ImageBox
+            src={updateInfo.image}
+            width="280px"
+            height="350px"
+            size="contain"></ImageBox>
+          <FlexBox type="flex">
+            <div>
+              <div>{updateInfo.name}</div>
+              {updateInfo.isMentor ? <div>멘토</div> : <div>멘토아님</div>}
+            </div>
+            <div>{updateInfo.rank}</div>
+          </FlexBox>
+        </S.HeaderContentsBox>
+        <S.HeaderContentsBox>설정</S.HeaderContentsBox>
+      </S.ContentContainer>
+      <S.ContentContainer>
+        <S.BodyContentsBox>
+          <div>소개</div>
+          <input
+            name="shortIntro"
+            type="text"
+            onChange={handleInputValue}
+            value={updateInfo.shortIntro}></input>
+        </S.BodyContentsBox>
+        <S.BodyContentsBox>
+          <div>주요경력</div>
+          <input
+            name="career"
+            type="text"
+            onChangeCapture={handleInputValue}
+            value={updateInfo.career}></input>
+        </S.BodyContentsBox>
+        <S.BodyContentsBox>
+          <div>관심카테고리</div>
+          <input
+            name="customCategory"
+            type="text"
+            onChange={handleInputValue}
+            value={updateInfo.customCategory}></input>
+        </S.BodyContentsBox>
+      </S.ContentContainer>
+      <S.ContentContainer>
+        <S.DetailBox>
+          <div>세부사항</div>
+          <input
+            name="detail"
+            type="text"
+            onChange={handleInputValue}
+            value={updateInfo.detail}></input>
+        </S.DetailBox>
+      </S.ContentContainer>
+      <S.ContentContainer>
+        <S.ShareBox>
+          <div>포트폴리오</div>
+          <input
+            name="portfolio"
+            type="text"
+            onChange={handleInputValue}
+            value={updateInfo.portfolio}></input>
+        </S.ShareBox>
+        <S.ShareBox>
+          <div>SNS</div>
+          <input
+            name="sns"
+            type="text"
+            onChange={handleInputValue}
+            value={updateInfo.sns}></input>
+        </S.ShareBox>
+      </S.ContentContainer>
+      <div onClick={handleUpdateProfile}>변경</div>
+    </div>
+  );
+};
+
+export default UpdateMyProfile;

--- a/src/components/organisms/my-profile/styled.tsx
+++ b/src/components/organisms/my-profile/styled.tsx
@@ -8,7 +8,7 @@ export const ContentContainer = styled.div`
 
 export const HeaderContentsBox = styled.div`
   width: 35%;
-  height: 4v60px;
+  height: 460px;
 `;
 
 export const BodyContentsBox = styled.div`

--- a/src/components/organisms/my-profile/styled.tsx
+++ b/src/components/organisms/my-profile/styled.tsx
@@ -1,0 +1,28 @@
+import styled from 'styled-components';
+
+export const ContentContainer = styled.div`
+  display: flex;
+  width: 70vw;
+  padding: 10px;
+`;
+
+export const HeaderContentsBox = styled.div`
+  width: 35%;
+  height: 4v60px;
+`;
+
+export const BodyContentsBox = styled.div`
+  width: 35%;
+  height: 120px;
+`;
+
+export const DetailBox = styled.div`
+  width: 80%;
+  min-height: 120px;
+  height: auto;
+`;
+
+export const ShareBox = styled.div`
+  width: 45%;
+  height: 120px;
+`;

--- a/src/components/templates/mypage-template/MyProfileTemplate.tsx
+++ b/src/components/templates/mypage-template/MyProfileTemplate.tsx
@@ -1,0 +1,24 @@
+import {
+  ButtonBox,
+  ContainerWrapper,
+} from '@/components/common/globalStyled/styled';
+import * as S from './styled';
+import MyProfileContents from '@/components/organisms/my-profile/MyProfileConetents';
+import { useRouter } from 'next/router';
+
+const MyProfileTemplate = () => {
+  const router = useRouter();
+  const handleBack = () => {
+    router.back();
+  };
+  return (
+    <ContainerWrapper>
+      <S.ContentContainer>
+        <ButtonBox onClick={handleBack}>이전</ButtonBox>
+        <MyProfileContents />
+      </S.ContentContainer>
+    </ContainerWrapper>
+  );
+};
+
+export default MyProfileTemplate;

--- a/src/components/templates/mypage-template/UpdateMyProfileTemplate.tsx
+++ b/src/components/templates/mypage-template/UpdateMyProfileTemplate.tsx
@@ -1,0 +1,15 @@
+import { ContainerWrapper } from '@/components/common/globalStyled/styled';
+import UpdateMyProfile from '@/components/organisms/my-profile/UpdateMyProfile';
+import * as S from './styled';
+
+const UpdateMyProfileTemplate = () => {
+  return (
+    <ContainerWrapper>
+      <S.ContentContainer>
+        <UpdateMyProfile />
+      </S.ContentContainer>
+    </ContainerWrapper>
+  );
+};
+
+export default UpdateMyProfileTemplate;

--- a/src/components/templates/mypage-template/styled.ts
+++ b/src/components/templates/mypage-template/styled.ts
@@ -174,3 +174,11 @@ export const ChatLinkText = styled.div`
   position: absolute;
   color: #fff;
 `;
+
+//MyProfileTemplate
+export const ContentContainer = styled.div`
+  display: flex;
+  border: 2px solid #98f;
+  width: 65%;
+  margin: 100px 50px 100px 0px;
+`;

--- a/src/pages/mypage/info/index.tsx
+++ b/src/pages/mypage/info/index.tsx
@@ -1,7 +1,12 @@
+import MyProfileTemplate from '@/components/templates/mypage-template/MyProfileTemplate';
 import React from 'react';
 
 const MyPageInfo = () => {
-  return <div>본인 정보 페이지</div>;
+  return (
+    <div>
+      <MyProfileTemplate />
+    </div>
+  );
 };
 
 export default MyPageInfo;

--- a/src/pages/mypage/info/update/index.tsx
+++ b/src/pages/mypage/info/update/index.tsx
@@ -1,0 +1,10 @@
+import UpdateMyProfileTemplate from '@/components/templates/mypage-template/UpdateMyProfileTemplate';
+
+const UpdateProfile = () => {
+  return (
+    <div>
+      <UpdateMyProfileTemplate />
+    </div>
+  );
+};
+export default UpdateProfile;

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -1,3 +1,9 @@
+/** 유저 타입 제네릭 */
+type UserType<T> = {
+  id: number;
+  name: string;
+} & T;
+
 /**멘토(유저)카드 타입
  * 멘토코멘트 개수 추가 필요
  * 유저 랭크 추가 필요
@@ -76,3 +82,33 @@ export type PopularMentorType = {
   rank: number;
   reviewCount: number;
 };
+
+/**UserType의 제네릭을 활용한 profileType */
+export type UserProfileType = UserType<{
+  activityCategoryId: number;
+  hopeCategoryId: number;
+  image: string;
+  intro: {
+    career: string;
+    customCategory: string;
+    detail: string;
+    portfolio: string;
+    shortIntro: string;
+    sns: string;
+  };
+  isMentor: boolean;
+  rank: number;
+  phone: string;
+}>;
+
+export interface UpdateProfileType {
+  activityCategoryId: number;
+  hopeCategoryId: number;
+  career: string;
+  customCategory: string;
+  detail: string;
+  portfolio: string;
+  shortIntro: string;
+  sns: string;
+  isMentor: boolean;
+}


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
브랜치 잘못해서 작업했습니다...원래 user-1 issue에서 작업하는 내용인데 담부턴 브랜치 설정 잘하겠습니다...
- 유저(본인) 정보 조회 api와 수정기능을 구현했습니다. 이전에 crab에서 ```comment```작업하던 것과 비슷한 형식이라 쉽게 구현했습니다(사실 좀 걸림)
- ```count```쪽에서 에러가 나서 준혁이한테 말하니깐 준혁이 쪽에서 데이터의 값을 바꿨더군요... 그래서 변경했습니다. 이번 작업 내용과 상관없는 내용이지만, 변경안하면, 계속 에러날 것 같아서 진행했습니다.

<!-- 추가예정 내용 (있다면 필수)-->
### Schedule
- 아직 ```activityCategoryId```랑 ```hopeCategoryId``` 수정 부분을 추가 안해서 진행할 예정입니다.
- ```image변경``` 추가할 예정입니다.
- ```isMentor``` 토글로 체크하는 방식을 추가할 예정입니다.

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer
작업한 부분이 본인 프로필 확인과, 수정이라, ```component```추가가 좀 있습니다. 파일체인지 많은 이유가 그 이유 입니다.