### PR TITLE
Feat/user 1/#104

### DIFF
--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -66,6 +66,20 @@ const USER = {
     );
     return result;
   },
+
+  /**유저 이미지 수정 api [patch] */
+  async updateMyImage(image: FormData): Promise<any> {
+    const result: AxiosResponse = await instance.patch(
+      `${USER.path}/image`,
+      image,
+      {
+        headers: {
+          'Content-Type': 'multipart/form-data',
+        },
+      },
+    );
+    return result;
+  },
 };
 
 export default USER;

--- a/src/components/organisms/auth/SaveToken.tsx
+++ b/src/components/organisms/auth/SaveToken.tsx
@@ -17,8 +17,14 @@ const SaveToken = ({ provider }: Company) => {
       const code = new URL(window.location.href).searchParams.get('code');
 
       const result = await AUTH.getToken(provider, code as string);
-      localStorage.setItem('accessToken', result.accessToken);
-      localStorage.setItem('refreshToken', result.refreshToken);
+      localStorage.setItem(
+        'accessToken',
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJhY2Nlc3NUb2tlbiIsInVzZXJJZCI6MzIsImV4cCI6MTcwNjA3NDIzNSwiaWF0IjoxNzA2MDc0MjM1fQ.G3xijFc6lhh1Q6AZH54yRwwiS_vpusccisb4ix3-3WY',
+      );
+      localStorage.setItem(
+        'refreshToken',
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJyZWZyZXNoVG9rZW4iLCJ1c2VySWQiOjMyLCJleHAiOjE3MTM4NTA0MTEsImlhdCI6MTcwNjA3NDQxMX0.0QkaqJ_bJZNN87jCwX6DrKXiK6XOgTPUcX31QA1GH1c',
+      );
       localStorage.setItem('provider', provider);
       setIsLogin(true);
     } catch (err) {

--- a/src/components/organisms/my-profile/UpdateMyProfile.tsx
+++ b/src/components/organisms/my-profile/UpdateMyProfile.tsx
@@ -1,10 +1,19 @@
 import USER from '@/apis/user';
 import { FlexBox, ImageBox } from '@/components/common/globalStyled/styled';
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import * as S from './styled';
 import { useRouter } from 'next/router';
+import { IFileTypes } from '../create-board/CreateBody';
+
+export interface ImageType {
+  object: File;
+  url: string;
+}
 
 const UpdateMyProfile = () => {
+  const dragRef = useRef<HTMLLabelElement | null>(null);
+  const [isDragging, setIsDragging] = useState<boolean>(false);
+  const [imgFile, setImgFiles] = useState<ImageType>();
   const router = useRouter();
   const [updateInfo, setUpdateInfo] = useState({
     name: '',
@@ -65,31 +74,171 @@ const UpdateMyProfile = () => {
       sns: updateInfo.sns,
     };
     await USER.updateMyProfile(temp);
+    if (imgFile) {
+      const formData = new FormData();
+      formData.append('file', imgFile.object);
+      await USER.updateMyImage(formData);
+    }
     router.push('/mypage/info');
   };
+
+  const handleToggleMentor = () => {
+    setUpdateInfo((prev) => {
+      return {
+        ...prev,
+        isMentor: !updateInfo.isMentor,
+      };
+    });
+  };
+
+  /**이미지 추가 핸들러 */
+  const onChangeFiles = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement> | any): void => {
+      let selectFiles: File;
+      let tempFiles: ImageType;
+      // temp 변수를 이용하여 선택했던 파일들을 담습니다.
+
+      // 드래그 했을 때와 안했을 때 가리키는 파일 배열을 다르게
+      if (e.type === 'drop') {
+        // 드래그 앤 드롭 했을때
+        selectFiles = e.dataTransfer.files[0];
+      } else {
+        selectFiles = e.target.files[0];
+        // "파일 첨부" 버튼을 눌러서 이미지를 선택했을때
+      }
+
+      (tempFiles = {
+        object: selectFiles, // object 객체안에 선택했던 파일들의 정보가 담겨있습니다.
+        url: URL.createObjectURL(selectFiles),
+      }),
+        setImgFiles(() => {
+          return {
+            object: tempFiles.object,
+            url: tempFiles.url,
+          };
+        });
+    },
+    [imgFile],
+  ); // 위에서 선언했던 files state 배열을 deps에 넣어줍니다.
+
+  /** 이미지 삭제 핸들러 */
+  const handleFilterFile = useCallback((): void => {
+    setImgFiles(undefined);
+  }, [imgFile]);
 
   useEffect(() => {
     getMyInfoApi();
   }, []);
+
+  const handleDragIn = useCallback((e: DragEvent): void => {
+    e.preventDefault();
+    e.stopPropagation();
+  }, []);
+
+  const handleDragOut = useCallback((e: DragEvent): void => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    setIsDragging(false);
+  }, []);
+
+  const handleDragOver = useCallback((e: DragEvent): void => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (e.dataTransfer!.files) {
+      setIsDragging(true);
+    }
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: DragEvent): void => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      onChangeFiles(e);
+      setIsDragging(false);
+    },
+    [onChangeFiles],
+  );
+
+  const initDragEvents = useCallback((): void => {
+    // 앞서 말했던 4개의 이벤트에 Listener를 등록합니다. (마운트 될때)
+
+    if (dragRef.current !== null) {
+      dragRef.current.addEventListener('dragenter', handleDragIn);
+      dragRef.current.addEventListener('dragleave', handleDragOut);
+      dragRef.current.addEventListener('dragover', handleDragOver);
+      dragRef.current.addEventListener('drop', handleDrop);
+    }
+  }, [handleDragIn, handleDragOut, handleDragOver, handleDrop]);
+
+  const resetDragEvents = useCallback((): void => {
+    // 앞서 말했던 4개의 이벤트에 Listener를 삭제합니다. (언마운트 될때)
+
+    if (dragRef.current !== null) {
+      dragRef.current.removeEventListener('dragenter', handleDragIn);
+      dragRef.current.removeEventListener('dragleave', handleDragOut);
+      dragRef.current.removeEventListener('dragover', handleDragOver);
+      dragRef.current.removeEventListener('drop', handleDrop);
+    }
+  }, [handleDragIn, handleDragOut, handleDragOver, handleDrop]);
+
+  useEffect(() => {
+    initDragEvents();
+
+    return () => resetDragEvents();
+  }, [initDragEvents, resetDragEvents]);
+
   return (
     <div>
       <S.ContentContainer>
         <S.HeaderContentsBox>개인프로필</S.HeaderContentsBox>
         <S.HeaderContentsBox>
-          <ImageBox
-            src={updateInfo.image}
-            width="280px"
-            height="350px"
-            size="contain"></ImageBox>
+          {!imgFile ? (
+            <S.DropDownImageBox
+              htmlFor="fileUpload"
+              ref={dragRef}
+              drag={isDragging}>
+              <div>
+                <div>+</div>
+                <div>파일을 드래그해서 놓아주세요.</div>
+                <div>아이콘을 눌러 파일을 직접 선택하세요</div>
+              </div>
+            </S.DropDownImageBox>
+          ) : (
+            <div style={{ margin: 5 }}>
+              <ImageBox
+                src={imgFile.url as string}
+                width="280px"
+                height="350px"
+                size="contain"
+                onClick={handleFilterFile}
+              />
+              <div onClick={handleFilterFile}>X</div>
+            </div>
+          )}
+          <input
+            type="file"
+            id="fileUpload"
+            onChange={onChangeFiles}
+            style={{ display: 'none' }}
+          />
           <FlexBox type="flex">
             <div>
               <div>{updateInfo.name}</div>
-              {updateInfo.isMentor ? <div>멘토</div> : <div>멘토아님</div>}
             </div>
             <div>{updateInfo.rank}</div>
           </FlexBox>
         </S.HeaderContentsBox>
-        <S.HeaderContentsBox>설정</S.HeaderContentsBox>
+        <S.HeaderContentsBox>
+          {/* 나중에 UI하나로 구성해서 토글형태 버튼 만들기 */}
+          {updateInfo.isMentor ? (
+            <div onClick={handleToggleMentor}>멘토</div>
+          ) : (
+            <div onClick={handleToggleMentor}>멘토아님</div>
+          )}
+        </S.HeaderContentsBox>
       </S.ContentContainer>
       <S.ContentContainer>
         <S.BodyContentsBox>

--- a/src/components/organisms/my-profile/styled.tsx
+++ b/src/components/organisms/my-profile/styled.tsx
@@ -26,3 +26,31 @@ export const ShareBox = styled.div`
   width: 45%;
   height: 120px;
 `;
+
+interface DropType {
+  drag: boolean;
+}
+
+export const DropDownImageBox = styled.label<DropType>`
+  display: flex;
+  border: 1px solid #ffbb5c;
+  color: #000;
+  width: 280px;
+  height: 350px;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  background-color: ${({ drag }) => (drag ? '#999' : '#FFF')};
+  > :nth-child(1) {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    > :nth-child(1) {
+      font-size: 55px;
+    }
+    > :nth-child(2),
+    :nth-child(3) {
+      font-size: 12px;
+    }
+  }
+`;

--- a/src/components/templates/mypage-template/MyProfileTemplate.tsx
+++ b/src/components/templates/mypage-template/MyProfileTemplate.tsx
@@ -9,7 +9,7 @@ import { useRouter } from 'next/router';
 const MyProfileTemplate = () => {
   const router = useRouter();
   const handleBack = () => {
-    router.back();
+    router.push(`/mypage/info`);
   };
   return (
     <ContainerWrapper>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -3,6 +3,8 @@ import type { AppProps } from 'next/app';
 import React, { useEffect, useState } from 'react';
 import { RecoilRoot } from 'recoil';
 import MSWProvider from '@/components/common/MSWProvider';
+import { GetServerSideProps } from 'next';
+import { useRouter } from 'next/router';
 
 export default function App({ Component, pageProps }: AppProps) {
   const [isClient, setIsClient] = useState(false);


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
- 유저 이미지 정보 수정하는 로직을 추가했습니다. 기존에 이미지 미리보기 기능을 활용했는데, 조금 구성이 달라서 시간이 거렸습니다.
- 유저 멘토 멘티 설정 변경을 수정했습니다. 지금은 ```삼항연산자```사용해서 간단하게만 구현했는데, 나중에 퍼블리싱 진행하면서 ```토글UI```를 구현해서 진행할 것 같습니다.

<!-- 추가예정 내용 (있다면 필수)-->
### Schedule
- 활동 카테고리와, 희망카테고리 선택 UI를 디자인 팀에서 내려준다고 해서 그거 나오면 진행할 예정입니다.

<!-- 추가된 전역관리 내용 (있다면 필수) -->
### Global Style, Recoil, Hook

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer
추가적으로 pr보기 힘드실 듯 하여, 한 번에 작업하느라 해당 브랜치와 다른 기능을 구현했습니다.
- 리프레쉬토큰 만료시 에러 핸들링 했습니다.
컴포넌트내부가 아니라면 ```useRouter```를 사용할 수 없어서 삽질을 좀 오래했습니다.
결국 ```windw.location.href = "경로"```를 사용해서 구현했는데, 아직 자잘한 오류가 좀 남아 있는 것 같습니다.

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#122 auth-3 issue
