### PR TITLE
마이페이지 기능추가

### DIFF
--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -64,7 +64,7 @@ instance.interceptors.response.use(
       }
       const accessToken = localStorage.getItem('accessToken');
 
-      error.config.headers['Authorization'] = `Bearer ${accessToken}`;
+      error.config.headers['Authorization'] = ` Bearer ${accessToken}`;
 
       // 중단된 요청을(에러난 요청)을 토큰 갱신 후 재요청
       const response = await instance(error.config);

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -80,6 +80,12 @@ const USER = {
     );
     return result;
   },
+
+  /**유저 온도/칭호 조회 api */
+  async getMyRank(): Promise<any> {
+    const result: AxiosResponse = await instance.get(`${USER.path}/my/rank`);
+    return result.data;
+  },
 };
 
 export default USER;

--- a/src/components/common/rank/rankList.ts
+++ b/src/components/common/rank/rankList.ts
@@ -1,0 +1,37 @@
+export const rankList = [
+  {
+    id: 1,
+    range: [1, 15],
+    rank: '수습생',
+    image:
+      'https://menbosha-s3.s3.ap-northeast-2.amazonaws.com/public/rank/rank1.svg',
+  },
+  {
+    id: 2,
+    range: [15, 50],
+    rank: '조리사',
+    image:
+      'https://menbosha-s3.s3.ap-northeast-2.amazonaws.com/public/rank/rank2.svg',
+  },
+  {
+    id: 3,
+    range: [50, 120],
+    rank: '조리장',
+    image:
+      'https://menbosha-s3.s3.ap-northeast-2.amazonaws.com/public/rank/rank3.svg',
+  },
+  {
+    id: 4,
+    range: [120, 200],
+    rank: '주방장',
+    image:
+      'https://menbosha-s3.s3.ap-northeast-2.amazonaws.com/public/rank/rank4.svg',
+  },
+  {
+    id: 5,
+    range: [200, 300],
+    rank: '총주방장',
+    image:
+      'https://menbosha-s3.s3.ap-northeast-2.amazonaws.com/public/rank/rank5.svg',
+  },
+];

--- a/src/components/organisms/my-badge/MyBadge.tsx
+++ b/src/components/organisms/my-badge/MyBadge.tsx
@@ -1,0 +1,7 @@
+import { RankType } from '@/types/user';
+
+const MyBadge = ({ badge }: Partial<RankType>) => {
+  return <div>칭호</div>;
+};
+
+export default MyBadge;

--- a/src/components/organisms/my-badge/MyRank.tsx
+++ b/src/components/organisms/my-badge/MyRank.tsx
@@ -1,0 +1,37 @@
+import { FlexBox } from '@/components/common/globalStyled/styled';
+import { rankList } from '@/components/common/rank/rankList';
+import { RankType } from '@/types/user';
+import { useEffect, useState } from 'react';
+import * as S from './styled';
+
+const MyRank = ({ rank }: Partial<RankType>) => {
+  const [myRank, setMyRank] = useState('');
+  const [rankImg, setRankImg] = useState('');
+  useEffect(() => {
+    if (rank) {
+      const temp = rankList.find(
+        (data) => data.range[0] < rank && data.range[1] > rank,
+      );
+      temp && setMyRank(temp.rank);
+      temp && setRankImg(temp.image);
+    }
+  });
+  return (
+    <div>
+      <S.RankTitleBox>등급 및 칭호</S.RankTitleBox>
+      <img src={rankImg} />
+      <div>{myRank}</div>
+      {rankList.map((data) => {
+        return <img src={data.image}></img>;
+      })}
+      <div></div>
+      <FlexBox type="flex">
+        {rankList.map((data) => {
+          return <div>{data.rank}</div>;
+        })}
+      </FlexBox>
+    </div>
+  );
+};
+
+export default MyRank;

--- a/src/components/organisms/my-badge/styled.tsx
+++ b/src/components/organisms/my-badge/styled.tsx
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const RankTitleBox = styled.div`
+  font-size: 64px;
+  color: #ffffff;
+  width: 220px;
+`;

--- a/src/components/templates/mypage-template/BadgeTemplate.tsx
+++ b/src/components/templates/mypage-template/BadgeTemplate.tsx
@@ -1,0 +1,48 @@
+import USER from '@/apis/user';
+import { ContainerWrapper } from '@/components/common/globalStyled/styled';
+import MyBadge from '@/components/organisms/my-badge/MyBadge';
+import MyRank from '@/components/organisms/my-badge/MyRank';
+import { RankType } from '@/types/user';
+import { useEffect, useState } from 'react';
+import * as S from './styled';
+import { useRouter } from 'next/router';
+
+const BadgeTemplate = () => {
+  const [rankData, setRankData] = useState<RankType>();
+  const router = useRouter();
+
+  const getMyRankApi = async () => {
+    const response = await USER.getMyRank();
+    setRankData(response);
+  };
+
+  const handleBack = () => {
+    router.push('/mypage');
+  };
+
+  console.log(rankData);
+
+  useEffect(() => {
+    getMyRankApi();
+  }, []);
+
+  return (
+    <ContainerWrapper>
+      {rankData ? (
+        <div>
+          <div onClick={handleBack}>이전</div>
+          <MyRank rank={rankData.rank} />
+          <MyBadge badge={rankData.badge} />
+        </div>
+      ) : (
+        <div>Loading...</div>
+      )}
+      <S.BadgeBack>
+        <div></div>
+        <div></div>
+      </S.BadgeBack>
+    </ContainerWrapper>
+  );
+};
+
+export default BadgeTemplate;

--- a/src/components/templates/mypage-template/MyPageTemplate.tsx
+++ b/src/components/templates/mypage-template/MyPageTemplate.tsx
@@ -46,8 +46,8 @@ const MyPageTemplate = () => {
           </S.ReviewLinkImg>
         </S.ElementSection>
         <S.ElementSection>
-          <S.ChatLinkImg onClick={() => handleRouter(`/chat`)}>
-            <S.ChatLinkText>채팅</S.ChatLinkText>
+          <S.ChatLinkImg onClick={() => handleRouter(`/mypage/record`)}>
+            <S.ChatLinkText>게시글 및 덧글</S.ChatLinkText>
           </S.ChatLinkImg>
         </S.ElementSection>
       </S.UserpageWrapper>

--- a/src/components/templates/mypage-template/MyProfileTemplate.tsx
+++ b/src/components/templates/mypage-template/MyProfileTemplate.tsx
@@ -9,7 +9,7 @@ import { useRouter } from 'next/router';
 const MyProfileTemplate = () => {
   const router = useRouter();
   const handleBack = () => {
-    router.push(`/mypage/info`);
+    router.push(`/mypage`);
   };
   return (
     <ContainerWrapper>
@@ -17,6 +17,10 @@ const MyProfileTemplate = () => {
         <ButtonBox onClick={handleBack}>이전</ButtonBox>
         <MyProfileContents />
       </S.ContentContainer>
+      <S.MyProfileBack>
+        <div></div>
+        <div></div>
+      </S.MyProfileBack>
     </ContainerWrapper>
   );
 };

--- a/src/components/templates/mypage-template/MyRecordTemplate.tsx
+++ b/src/components/templates/mypage-template/MyRecordTemplate.tsx
@@ -1,0 +1,16 @@
+import { ContainerWrapper } from '@/components/common/globalStyled/styled';
+import * as S from './styled';
+
+const MyRecordTemplate = () => {
+  return (
+    <ContainerWrapper>
+      <div>기록</div>
+      <S.MyRecordBack>
+        <div></div>
+        <div></div>
+      </S.MyRecordBack>
+    </ContainerWrapper>
+  );
+};
+
+export default MyRecordTemplate;

--- a/src/components/templates/mypage-template/MyReviewTemplate.tsx
+++ b/src/components/templates/mypage-template/MyReviewTemplate.tsx
@@ -1,0 +1,16 @@
+import { ContainerWrapper } from '@/components/common/globalStyled/styled';
+import * as S from './styled';
+
+const MyReviewTemplate = () => {
+  return (
+    <ContainerWrapper>
+      <div>리뷰</div>
+      <S.MyReviewBack>
+        <div></div>
+        <div></div>
+      </S.MyReviewBack>
+    </ContainerWrapper>
+  );
+};
+
+export default MyReviewTemplate;

--- a/src/components/templates/mypage-template/styled.ts
+++ b/src/components/templates/mypage-template/styled.ts
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import styled, { keyframes } from 'styled-components';
+import styled, { css, keyframes } from 'styled-components';
 
 /**유저 페이지 최상위 */
 export const UserpageWrapper = styled.div`
@@ -106,7 +106,7 @@ export const ProfileLinkImg = styled.div`
 export const ProfileLinkText = styled.div`
   margin: 14% 0% 0% 8%;
   position: absolute;
-  color: #fff;
+  color: #ff772b;
 `;
 
 export const TempLinkImg = styled.div`
@@ -128,7 +128,7 @@ export const TempLinkImg = styled.div`
 export const TempLinkText = styled.div`
   margin: 14% 0% 0% 9%;
   position: absolute;
-  color: #fff;
+  color: #ff772b;
 `;
 
 export const ReviewLinkImg = styled.div`
@@ -150,7 +150,7 @@ export const ReviewLinkImg = styled.div`
 export const ReviewLinkText = styled.div`
   margin: 14% 0% 0% 11%;
   position: absolute;
-  color: #fff;
+  color: #ff772b;
 `;
 
 export const ChatLinkImg = styled.div`
@@ -172,7 +172,7 @@ export const ChatLinkImg = styled.div`
 export const ChatLinkText = styled.div`
   margin: 14% 0% 0% 11%;
   position: absolute;
-  color: #fff;
+  color: #ff772b;
 `;
 
 //MyProfileTemplate
@@ -181,4 +181,64 @@ export const ContentContainer = styled.div`
   border: 2px solid #98f;
   width: 65%;
   margin: 100px 50px 100px 0px;
+`;
+
+const BackGround = css`
+  > :nth-child(1) {
+    width: 0px;
+    height: 100px;
+    border-right: 1000px solid #fff;
+    border-top: 300px solid transparent;
+    border-bottom: 0px solid transparent;
+    position: absolute;
+    z-index: -1;
+    top: 73vw;
+    left: 1000px;
+    &::after {
+      height: 100px;
+      content: '';
+      border-left: 1000px solid #fff;
+      border-top: 300px solid transparent;
+      border-bottom: 0px solid transparent;
+      position: absolute;
+      top: -300px;
+      left: -1000px;
+    }
+  }
+  > :nth-child(2) {
+    width: 100000px;
+    height: 1000000px;
+    left: -50vw;
+    top: -50vw;
+    position: fixed;
+    z-index: -2;
+  }
+`;
+
+export const BadgeBack = styled.div`
+  ${BackGround}
+  > :nth-child(2) {
+    background-color: #b83a42;
+  }
+`;
+
+export const MyProfileBack = styled.div`
+  ${BackGround}
+  > :nth-child(2) {
+    background-color: #ff772b;
+  }
+`;
+
+export const MyReviewBack = styled.div`
+  ${BackGround}
+  >:nth-child(2) {
+    background-color: #752626;
+  }
+`;
+
+export const MyRecordBack = styled.div`
+  ${BackGround}
+  >:nth-child(2) {
+    background-color: #4e1f1f;
+  }
 `;

--- a/src/pages/mypage/badge/index.tsx
+++ b/src/pages/mypage/badge/index.tsx
@@ -1,7 +1,12 @@
+import BadgeTemplate from '@/components/templates/mypage-template/BadgeTemplate';
 import React from 'react';
 
 const MypageBadge = () => {
-  return <div>온도/칭호 페이지</div>;
+  return (
+    <div>
+      <BadgeTemplate />
+    </div>
+  );
 };
 
 export default MypageBadge;

--- a/src/pages/mypage/record/index.tsx
+++ b/src/pages/mypage/record/index.tsx
@@ -1,0 +1,11 @@
+import MyRecordTemplate from '@/components/templates/mypage-template/MyRecordTemplate';
+
+const MypageRecord = () => {
+  return (
+    <div>
+      <MyRecordTemplate />
+    </div>
+  );
+};
+
+export default MypageRecord;

--- a/src/pages/mypage/review/index.tsx
+++ b/src/pages/mypage/review/index.tsx
@@ -1,5 +1,11 @@
+import MyReviewTemplate from '@/components/templates/mypage-template/MyReviewTemplate';
+
 const MypageReview = () => {
-  return <div>유저 후기 페이지</div>;
+  return (
+    <div>
+      <MyReviewTemplate />
+    </div>
+  );
 };
 
 export default MypageReview;

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -112,3 +112,11 @@ export interface UpdateProfileType {
   sns: string;
   isMentor: boolean;
 }
+
+export type RankType = {
+  rank: number;
+  badge: {
+    badgeId: number;
+    createdAt: string;
+  }[];
+};


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
여러가지 작업을 짬뽕해서 해서 파일체인지가 많습니다.

- 랭크관련해서 값을 추가 했습니다. ```s3```에 사진 업로드 시켰고, 해당 사진을 받아와서 매핑 리스트를 만들고, ```map```으로 불러오거나 ```find```를 사용해서 값을 불러왔습니다. 
- 마이페이지에서 각 빵을 눌러 들어갔을 때,  ```background```에 들어갈 큰 이미지 구현을 했습니다. 마름모 모양이라 조금 이상한 부분이 있는데 이건 어쩔 수 없을 것 같아요. 
- 마이페이지에서 각 빵에 들어가는 라우트 때문에 새롭게 만든 파일이 몇 개 존재합니다. 아직 안쪽은 구현 안됐습니다.
<!-- 추가예정 내용 (있다면 필수)-->
### Schedule
- 후기 불러오기 구현
-> ```스웨거```에 ```/mentor/review```가 추가됐습니다. 아마 제가 마이페이지 구현하면서 파일 만들 예정이라 나중에 작업하시게되면 따로 연락주시면 좋을 것 같습니다.
- 본인이 쓴 게시글, 댓글 불러오는 기능구현
-> 현재 비호형이 구현중입니다. 구현 끝나는대로 구현 예정입니다.

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer
각 빵에 들어가서 보여주는 부분에서 같은 내용의 ```styled-components```가 과도하게 반복되는 부분이 있었습니다.
해당 부분을 아래 레퍼런스를 참고해서 만들었습니다. 수정된 파일에 표시해 두겠습니다.

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link
[styled-component 모듈화 작업 레퍼런스](https://velog.io/@taewo/react%EC%97%90%EC%84%9C-styled-component-css-%EB%AA%A8%EB%93%88-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0)
