### PR TITLE
멘토페이지 리뷰 불러오기 구현

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -47,7 +47,7 @@ const nextConfig = {
       },
     ],
   },
-  reactStrictMode: true,
+  reactStrictMode: false,
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/src/apis/mentors.ts
+++ b/src/apis/mentors.ts
@@ -1,0 +1,24 @@
+import { AxiosResponse } from 'axios';
+import { MentorReviewType } from '@/types/review';
+import instance from './axiosInstance';
+
+const MENTORS = {
+  path: '/mentors',
+
+  /**멘로 리뷰 조회 api [get] */
+  async getMentorReview(id: number, page: number): Promise<MentorReviewType> {
+    const result: AxiosResponse = await instance.get(
+      `${MENTORS.path}/${id}/reviews`,
+      {
+        params: {
+          sortOrder: 'DESC',
+          page: page,
+          pageSize: 5, //값 10개씩 불러오기
+        },
+      },
+    );
+    return result.data.contents;
+  },
+};
+
+export default MENTORS;

--- a/src/components/molecules/mentor-elements/MentorBadgeElements.tsx
+++ b/src/components/molecules/mentor-elements/MentorBadgeElements.tsx
@@ -1,0 +1,13 @@
+import { MentorBadgeType } from '@/types/mentor';
+import * as S from './styled';
+
+const MentorBadgeElement = ({ badgeId, createdAt }: MentorBadgeType) => {
+  return (
+    <S.BadgeBox>
+      <div>{badgeId}</div>
+      <div>{createdAt}</div>
+    </S.BadgeBox>
+  );
+};
+
+export default MentorBadgeElement;

--- a/src/components/molecules/mentor-elements/styled.tsx
+++ b/src/components/molecules/mentor-elements/styled.tsx
@@ -79,3 +79,11 @@ export const PopularMentorCardContainer = styled.div`
     border: 5px solid #ff792bbf;
   }
 `;
+
+export const BadgeBox = styled.div`
+  border: 2px solid #000;
+  border-radius: 15px;
+  height: 166px;
+  width: 30.3%;
+  margin: 14px;
+`;

--- a/src/components/molecules/mentor-review-elements/MentorReviewElements.tsx
+++ b/src/components/molecules/mentor-review-elements/MentorReviewElements.tsx
@@ -1,0 +1,13 @@
+import { ReviewProprType } from '@/types/review';
+import * as S from 'styled-components';
+
+const MentorReviewElements = (props: ReviewProprType) => {
+  return (
+    <div>
+      <div></div>
+      <div>{props.name}</div>
+    </div>
+  );
+};
+
+export default MentorReviewElements;

--- a/src/components/organisms/mentor/MentorReveiw.tsx
+++ b/src/components/organisms/mentor/MentorReveiw.tsx
@@ -1,0 +1,94 @@
+import MENTORS from '@/apis/mentors';
+import MentorReviewElements from '@/components/molecules/mentor-review-elements/MentorReviewElements';
+import { MentorReviewType } from '@/types/review';
+import { MentorUnitPropsType } from '@/types/user';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const MentorReview = ({ id }: MentorUnitPropsType) => {
+  const [reviewData, setReviewData] = useState<
+    MentorReviewType['mentorReviewsItemResponses']
+  >([]);
+  const [page, setPage] = useState(1);
+  const [totalPage, setTotalPage] = useState(1); //페이지 수
+  const obsRef = useRef<HTMLDivElement>(null); //옵저버 state
+  const [load, setLoad] = useState(false);
+  const preventRef = useRef(true); //옵저버 중복 방지
+  console.log('page', page);
+  console.log('tot', totalPage);
+
+  //옵저버 생성
+  useEffect(() => {
+    const observer = new IntersectionObserver(handleObs, { threshold: 0.5 });
+    if (obsRef.current) observer.observe(obsRef.current);
+    return () => {
+      observer.disconnect();
+    };
+  }, [obsRef, reviewData]);
+
+  const handleObs = (entries: any) => {
+    const target = entries[0];
+    if (target.isIntersecting) {
+      //옵저버 중복 실행 방지
+      preventRef.current = false; //옵저버 중복 실행 방지
+      setPage((prev) => prev + 1); //페이지 증가
+    }
+  };
+
+  const getMentorReviewApi = useCallback(async () => {
+    setLoad(true); //로딩 시작
+    if (page <= totalPage) {
+      const response = await MENTORS.getMentorReview(id, page);
+      setReviewData((prev) => [
+        ...prev,
+        ...response.mentorReviewsItemResponses,
+      ]);
+      setTotalPage(response.lastPage);
+    }
+    setLoad(false);
+  }, [page]);
+
+  useEffect(() => {
+    getMentorReviewApi();
+  }, [page]);
+
+  return (
+    <div>
+      {reviewData &&
+        reviewData.map((data) => {
+          const temp = {
+            id: data.id,
+            menteeId: data.mentee.id,
+            name: data.mentee.name,
+            rank: data.mentee.rank,
+            imageUrl: data.mentee.userImage.imageUrl,
+            customCategory: data.mentee.userIntro.customCategory,
+            career: data.mentee.userIntro.career,
+            shortIntro: data.mentee.userIntro.shortIntro,
+            review: data.review,
+            mentorReviewId: data.mentorReviewChecklist.mentorReviewId,
+            isGoodWork: data.mentorReviewChecklist.isGoodWork,
+            isClear: data.mentorReviewChecklist.isClear,
+            isQuick: data.mentorReviewChecklist.isQuick,
+            isAccurate: data.mentorReviewChecklist.isAccurate,
+            isKindness: data.mentorReviewChecklist.isKindness,
+            isFun: data.mentorReviewChecklist.isFun,
+            isInformative: data.mentorReviewChecklist.isInformative,
+            isBad: data.mentorReviewChecklist.isBad,
+            isStuffy: data.mentorReviewChecklist.isStuffy,
+            createdAt: data.createdAt,
+          };
+          return (
+            <div key={data.id}>
+              <MentorReviewElements {...temp} />
+            </div>
+          );
+        })}
+      <div>
+        {load && <div>Loading...</div>}
+        <div ref={obsRef}></div>
+      </div>
+    </div>
+  );
+};
+
+export default MentorReview;

--- a/src/components/organisms/mentor/MentorUnit.tsx
+++ b/src/components/organisms/mentor/MentorUnit.tsx
@@ -1,62 +1,133 @@
 import USER from '@/apis/user';
 import { FlexBox, ImageBox } from '@/components/common/globalStyled/styled';
-import MainPageHeader from '@/components/common/header/MainPageHeader';
 import { MentorType, MentorUnitPropsType, MentorUnitType } from '@/types/user';
 import { useEffect, useState } from 'react';
+import * as S from './styled';
+import { rankList } from '@/components/common/rank/rankList';
+import Image from 'next/image';
+import MentorBadgeElement from '@/components/molecules/mentor-elements/MentorBadgeElements';
+import { categoryList } from '@/components/common/category/categoryList';
+import { userInfo } from 'os';
 
 const MentorUnit = ({ id }: MentorUnitPropsType) => {
   const [getUserInfo, setUserInfo] = useState<MentorUnitType>();
+  const [getRank, setRank] = useState({
+    name: '',
+    image: '',
+  });
+  const [getCategory, setCategory] = useState('');
 
   const getUserInfoApi = async () => {
     const response = await USER.getUserInfo(id);
     setUserInfo(response);
   };
 
-  console.log(getUserInfo);
+  const getRankInfo = () => {
+    if (getUserInfo) {
+      const rankImage = rankList.find(
+        (data) =>
+          data.range[0] < getUserInfo.rank && data.range[1] > getUserInfo.rank,
+      );
+      rankImage &&
+        setRank((prev) => {
+          return {
+            ...prev,
+            name: rankImage.rank,
+            image: rankImage.image,
+          };
+        });
+    }
+  };
+
+  const findCategory = () => {
+    if (getUserInfo) {
+      const category = categoryList.find(
+        (data) => data.id === getUserInfo?.activityCategoryId,
+      )?.category;
+      category && setCategory(category);
+    }
+  };
 
   useEffect(() => {
     getUserInfoApi();
   }, []);
 
+  useEffect(() => {
+    getRankInfo();
+    findCategory();
+  }, [getUserInfo]);
+
   return (
     <div>
-      <FlexBox type="flex">
+      <S.ContentContainer>
+        <S.HeaderContentsBox>
+          <S.CustomImageBox
+            width="280px"
+            height="370px"
+            src={getUserInfo?.image}
+            alt="유저이미지"></S.CustomImageBox>
+          <FlexBox type="flex">
+            <div>
+              <FlexBox type="flex">
+                <div>{getUserInfo?.name}</div>
+                <div>{}</div>
+              </FlexBox>
+              {getUserInfo?.isMentor ? <div>멘토</div> : <div>멘토아님</div>}
+            </div>
+          </FlexBox>
+        </S.HeaderContentsBox>
         <div>
-          <ImageBox src={getUserInfo?.image as string} size="cover" />
-          <div>{getUserInfo?.name}</div>
+          <Image
+            width={150}
+            height={150}
+            src={getRank.image}
+            alt="랭크이미지"
+          />
+          <div>{getRank.name}</div>
+          <div>{getUserInfo?.rank}점</div>
         </div>
-        <div>
-          <div>랭크이미지</div>
-          <div>랭크들어올자리</div>
-        </div>
-      </FlexBox>
-      <FlexBox type="flex">
-        <div>
+      </S.ContentContainer>
+      <S.ContentContainer>
+        <S.BodyContentsBox>
           <div>소개</div>
-          <div>{getUserInfo?.intro.introduce}</div>
-        </div>
-        <div>
+          <div>{getUserInfo?.intro.shortIntro}</div>
+        </S.BodyContentsBox>
+        <S.BodyContentsBox>
           <div>주요경력</div>
           <div>{getUserInfo?.intro.career}</div>
-        </div>
-        <div>
-          <div>주요 카테고리</div>
-          <div>{getUserInfo?.intro.mainField}</div>
-        </div>
-      </FlexBox>
-      <div>
-        <div>설명들어올자리</div>
-      </div>
-      <FlexBox type="flex">
-        <div>
+        </S.BodyContentsBox>
+        <S.BodyContentsBox>
+          <div>관심카테고리</div>
+          <div>{getUserInfo?.intro.customCategory}</div>
+        </S.BodyContentsBox>
+      </S.ContentContainer>
+      <S.DetailBox>
+        <div>세부사항</div>
+        <div>{getUserInfo?.intro.detail}</div>
+      </S.DetailBox>
+      <S.ContentContainer>
+        <S.ShareBox>
           <div>포트폴리오</div>
-          <div>포트폴리오 들어올자리</div>
-        </div>
-        <div>
+          <div>{getUserInfo?.intro.portfolio}</div>
+        </S.ShareBox>
+        <S.ShareBox>
           <div>SNS</div>
-          <div>SNS들어올 자리</div>
-        </div>
-      </FlexBox>
+          <div>{getUserInfo?.intro.sns}</div>
+        </S.ShareBox>
+      </S.ContentContainer>
+      <div style={{ textAlign: 'center' }}>칭호</div>
+      <S.BadgeContainer>
+        {getUserInfo &&
+          getUserInfo.badge.map((data) => {
+            return (
+              <MentorBadgeElement
+                badgeId={data.badgeId}
+                createdAt={data.createdAt}
+              />
+            );
+          })}
+      </S.BadgeContainer>
+      <div>이 멘토의 다른 게시글</div>
     </div>
   );
 };

--- a/src/components/organisms/mentor/styled.ts
+++ b/src/components/organisms/mentor/styled.ts
@@ -12,3 +12,46 @@ export const MentorCardWrapper = styled.div`
   height: 460px;
   margin: 8px;
 `;
+
+interface ImageType {
+  width?: string;
+  height?: string;
+}
+
+/**MentorUni */
+export const CustomImageBox = styled.img<ImageType>`
+  width: ${({ width }) => (width ? width : '100px')};
+  height: ${({ height }) => (height ? height : '100px')};
+  border: 1px solid #ffbef2;
+`;
+
+export const HeaderContentsBox = styled.div`
+  width: 35%;
+  height: 460px;
+`;
+
+export const BodyContentsBox = styled.div`
+  width: 35%;
+  height: 120px;
+`;
+
+export const DetailBox = styled.div`
+  width: 80%;
+  min-height: 120px;
+  height: auto;
+`;
+
+export const ShareBox = styled.div`
+  width: 45%;
+  height: 120px;
+`;
+
+export const ContentContainer = styled.div`
+  display: flex;
+  width: 50vw;
+  padding: 10px;
+`;
+
+export const BadgeContainer = styled.div`
+  display: flex;
+`;

--- a/src/components/templates/mentor-template/MentorUnitTemplate.tsx
+++ b/src/components/templates/mentor-template/MentorUnitTemplate.tsx
@@ -1,8 +1,14 @@
-import { ButtonBox, TextBox } from '@/components/common/globalStyled/styled';
+import {
+  ButtonBox,
+  ContainerWrapper,
+  TextBox,
+} from '@/components/common/globalStyled/styled';
 import MainPageHeader from '@/components/common/header/MainPageHeader';
 import MentorUnit from '@/components/organisms/mentor/MentorUnit';
 import { useRouter } from 'next/router';
-import { useEffect } from 'react';
+import * as S from './styled';
+import Image from 'next/image';
+import MentorReview from '@/components/organisms/mentor/MentorReveiw';
 
 const MentorUnitTemplate = () => {
   const router = useRouter();
@@ -11,21 +17,19 @@ const MentorUnitTemplate = () => {
     router.back();
   };
   return (
-    <div>
+    <ContainerWrapper>
       <MainPageHeader />
-      <div
-        style={{ display: 'flex', justifyContent: 'center', height: '70vh' }}>
+      <S.ContentContainer>
         <div>
-          <TextBox color="#FF772B" size={64}>
-            멘토
-            <br />
-            프로필
-          </TextBox>
-          <ButtonBox onClick={handleBack}>이전버튼</ButtonBox>
+          <div>멘토 프로필</div>
+          <ButtonBox onClick={handleBack}>이전</ButtonBox>
         </div>
-        {router.isReady && <MentorUnit id={Number(router.query.id)} />}
-      </div>
-    </div>
+        <div>
+          {router.isReady && <MentorUnit id={Number(router.query.id)} />}
+        </div>
+      </S.ContentContainer>
+      {router.isReady && <MentorReview id={Number(router.query.id)} />}
+    </ContainerWrapper>
   );
 };
 

--- a/src/components/templates/mentor-template/styled.ts
+++ b/src/components/templates/mentor-template/styled.ts
@@ -34,3 +34,22 @@ export const MentorBoardListContainer = styled.div`
 export const PopularMentorListContainer = styled.div`
   height: 1100px;
 `;
+
+export const ContentContainer = styled.div`
+  display: flex;
+  border: 2px solid #98f;
+  width: 65%;
+  margin: 100px 50px 100px 0px;
+  > :nth-child(1) {
+    font-size: 64px;
+    font-weight: bold;
+    color: #ff772b;
+    width: 180px;
+  }
+  > :nth-child(2) {
+    width: 90%;
+    display: flex;
+    justify-content: center;
+    border: 2px solid #00f;
+  }
+`;

--- a/src/types/mentor.d.ts
+++ b/src/types/mentor.d.ts
@@ -158,3 +158,8 @@ export interface MentorHotBoardListType {
   imageUrl: string;
   likeCount: number;
 }
+
+export interface MentorBadgeType {
+  badgeId: number;
+  createdAt: string;
+}

--- a/src/types/review.d.ts
+++ b/src/types/review.d.ts
@@ -1,0 +1,63 @@
+export type MentorReviewType = {
+  totalCount: number;
+  currentPage: number;
+  pageSize: number;
+  nextPage: number;
+  hasNext: boolean;
+  lastPage: number;
+  mentorReviewsItemResponses: {
+    id: number;
+    mentee: {
+      id: number;
+      name: string;
+      rank: number;
+      userImage: {
+        imageUrl: string;
+      };
+      userIntro: {
+        customCategory: string;
+        career: string;
+        shortIntro: string;
+      };
+    };
+    review: string;
+    mentorReviewChecklist: {
+      id: number;
+      mentorReviewId: number;
+      isGoodWork: boolean;
+      isClear: boolean;
+      isQuick: boolean;
+      isAccurate: boolean;
+      isKindness: boolean;
+      isFun: boolean;
+      isInformative: boolean;
+      isBad: boolean;
+      isStuffy: boolean;
+    };
+    createdAt: boolean;
+  }[];
+};
+
+/**리뷰 props전달 타입 */
+export interface ReviewProprType {
+  id: number;
+  menteeId: number;
+  name: string;
+  rank: number;
+  imageUrl: string;
+  customCategory: string;
+  career: string;
+  shortIntro: string;
+  review: string;
+  mentorReviewId: number;
+  isGoodWork: boolean;
+  isClear: boolean;
+  isQuick: boolean;
+  isAccurate: boolean;
+  isKindness: boolean;
+  isFun: boolean;
+  isInformative: boolean;
+  isBad: boolean;
+  isStuffy: boolean;
+  createdAt: boolean;
+}

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -41,16 +41,20 @@ export type MentorUnitType = {
   isMentor: boolean;
   intro: {
     career: string;
-    introduce: string;
-    mainField: string;
+    shortIntro: string;
+    customCategory: string;
+    detail: string;
+    portfolio: string;
+    sns: string;
   };
   image: string;
   email: string;
   activityCategoryId: number;
   badge: {
     badgeId: number;
-    createAt: string;
+    createdAt: string;
   }[];
+  rank: number;
 };
 
 /**내 정보 조회 api Type */


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
멘토 페이지에 멘토 후기 불러오는 기능을 추가했습니다.
무한스크롤 형식으로 구현했구요, 기존이랑 다르게, 비호형이 내려준 값을 활용해서 무한 스크롤을 구현해서, 이 전과 형식이 다릅니다.
변경점 : 기존에 두 개의 api로 쪼개져 있었던 무한스크롤 api가 하나로 통합되었습니다. 동건이형 ```chat list````에서 무한스크롤 구현한 형식도 비호형한테 부탁해서 동일한 형식으로 바뀔 수 있습니다.

<!-- 추가예정 내용 (있다면 필수)-->
### Schedule
api에는 리뷰 수정,삭제 기능이 존재하는데, 기획상 구현하지 않을 수 있습니다.

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer
멘토쪽 값들을 넣느라 리뷰쪽 작업만 들어간게 아니라, 멘토쪽 전체적인 파일체인지가 있습니다. 보실 때 참고하세요
