### PR TITLE
Refactor/board 3/#129

### DIFF
--- a/src/apis/help.ts
+++ b/src/apis/help.ts
@@ -6,6 +6,8 @@ import {
   ModifyHelpUnitType,
   CreateHelpType,
   HelpListParamsType,
+  HelpCommentParamsType,
+  HelpCommentListApiType,
 } from '@/types/help';
 const HELP = {
   path: '/help-me-boards',
@@ -142,6 +144,24 @@ const HELP = {
       },
     );
     return result;
+  },
+
+  /**도와줄게요 댓글 불러오는 pagination */
+  async helpCommentPagination(
+    params: HelpCommentParamsType,
+  ): Promise<HelpCommentListApiType> {
+    const result: AxiosResponse = await instance.get(
+      `${HELP.path}/${params.helpBoardId}/help-you-comments`,
+      {
+        params: {
+          page: params.page,
+          pageSize: params.pageSize,
+          orderField: params.orderField,
+          sortOrder: params.sortOrder,
+        },
+      },
+    );
+    return result.data;
   },
 };
 

--- a/src/apis/help.ts
+++ b/src/apis/help.ts
@@ -5,9 +5,10 @@ import {
   HelpUnitType,
   ModifyHelpUnitType,
   CreateHelpType,
+  HelpListParamsType,
 } from '@/types/help';
 const HELP = {
-  path: '/help-me-board',
+  path: '/help-me-boards',
 
   /**도와줘요 게시판 생성 api [post]*/
   async createHelpBoard({
@@ -54,14 +55,16 @@ const HELP = {
   },
 
   /**리스트 불러오는 api */
-  async getHelpBoardList(
-    category: number,
-    page: number,
+  async getHelpBoardPagination(
+    params: HelpListParamsType,
   ): Promise<HelpListApiType> {
     const result: AxiosResponse = await instance.get(`${HELP.path}`, {
       params: {
-        categoryId: category !== 1 ? category : '',
-        page: page,
+        categoryId: params.categoryId !== 1 ? params.categoryId : 1,
+        loadOnlyPullingUp: params.loadOnlyPullingUp,
+        sortOrder: params.sortOrder,
+        pageSize: params.pageSize,
+        page: params.page,
       },
     });
     return result.data;
@@ -139,19 +142,6 @@ const HELP = {
       },
     );
     return result;
-  },
-
-  /** 도와주세요 끌올 리스트 api [get]*/
-  async getPullingUp(id: number): Promise<any> {
-    const result: AxiosResponse = await instance.get(
-      `${HELP.path}/pulling-up`,
-      {
-        params: {
-          categoryId: id !== 1 ? id : '',
-        },
-      },
-    );
-    return result.data.data;
   },
 };
 

--- a/src/apis/mentor.ts
+++ b/src/apis/mentor.ts
@@ -1,16 +1,15 @@
 import {
   CreateMentorBoardType,
   MentorBoardListType,
-  MentorBoardUnitType,
   MentorHotBoardPropsType,
+  MentorBoardParamsType,
 } from '@/types/mentor';
 import { AxiosResponse } from 'axios';
 import instance from './axiosInstance';
-import Category from '@/components/common/category/Category';
 import COUNT from './count';
 
 const MENTOR = {
-  path: `/mentor-board`,
+  path: `/mentor-boards`,
 
   /** 멘토 게시판 생성 api [post] */
   async createMentorBoard({
@@ -57,17 +56,20 @@ const MENTOR = {
   },
 
   /**페이지별 멘토 리스트 불러오는 api [get] */
-  async getMentorBoardList(
-    category: number,
-    page: number,
-  ): Promise<MentorBoardListType[]> {
+  async MentorBoardPagination(
+    params: MentorBoardParamsType,
+  ): Promise<MentorBoardListType> {
     const result: AxiosResponse = await instance.get(`${MENTOR.path}`, {
       params: {
-        categoryId: category !== 1 ? category : '',
-        page: page,
+        categoryId: params.categoryId !== 1 ? params.categoryId : 1,
+        pageSize: params.pageSize,
+        page: params.page,
+        loadOnlyPopular: params.loadOnlyPopular,
+        orderField: params.orderField,
+        sortOrder: params.sortOrder,
       },
     });
-    return result.data.data;
+    return result.data.contents;
   },
 
   /**멘토 게시물 불러오기 api [get] */

--- a/src/components/molecules/mentor-board-elements/MentorBoardCard.tsx
+++ b/src/components/molecules/mentor-board-elements/MentorBoardCard.tsx
@@ -3,7 +3,7 @@ import {
   ImageBox,
   TextBox,
 } from '@/components/common/globalStyled/styled';
-import { MentorBoardCardType } from '@/types/mentor';
+import { MentorBoardCardType, MentorBoardListType } from '@/types/mentor';
 import * as S from './styled';
 import { categoryList } from '@/components/common/category/categoryList';
 import { useRouter } from 'next/router';

--- a/src/components/organisms/help-board/HelpPullingBoardList.tsx
+++ b/src/components/organisms/help-board/HelpPullingBoardList.tsx
@@ -1,19 +1,31 @@
 import HelpCard from '@/components/molecules/help-board-elements/HelpCard';
 import * as S from './styled';
 import { useEffect, useState } from 'react';
-import { PullingUpType } from '@/types/help';
+import {
+  HelpListApiType,
+  HelpListParamsType,
+  PullingUpType,
+} from '@/types/help';
 import HELP from '@/apis/help';
 import { useRecoilValue } from 'recoil';
 import { CategoryFilterAtom } from '@/recoil/atoms/CategorySelectAtom';
 
 const HelpPullingBoardList = () => {
-  const [getPullingData, setPullingData] = useState<PullingUpType[]>([]);
+  const [getPullingData, setPullingData] = useState<
+    HelpListApiType['helpMeBoardWithUserAndImagesItemDto']
+  >([]);
   const filterCategory = useRecoilValue(CategoryFilterAtom);
 
   const getPullingUpApi = async () => {
-    const response = await HELP.getPullingUp(filterCategory);
-    const temp = response.filter((data: any, idx: number) => idx < 5);
-    setPullingData(temp);
+    const params: HelpListParamsType = {
+      categoryId: filterCategory,
+      loadOnlyPullingUp: true,
+      sortOrder: 'DESC',
+      orderField: 'id',
+      pageSize: 5,
+    };
+    const response = await HELP.getHelpBoardPagination(params);
+    setPullingData(response.helpMeBoardWithUserAndImagesItemDto);
   };
 
   useEffect(() => {

--- a/src/components/organisms/mentor-board/MentorBoardList.tsx
+++ b/src/components/organisms/mentor-board/MentorBoardList.tsx
@@ -70,7 +70,7 @@ const MentorBoardList = () => {
       pageSize: 10,
     };
     setLoad(true); //로딩 시작
-    if (totalPage > 0) {
+    if (page <= totalPage) {
       //나중에 카테고리 전역으로 관리 예정
       const response = await MENTOR.MentorBoardPagination(temp); //api요청 글 목록 불러오기
       setBoardData((prev: any) => [

--- a/src/components/organisms/mentor-board/PopularMentorBoardList.tsx
+++ b/src/components/organisms/mentor-board/PopularMentorBoardList.tsx
@@ -1,6 +1,10 @@
 import MENTOR from '@/apis/mentor';
 import MentorBoardCard from '@/components/molecules/mentor-board-elements/MentorBoardCard';
-import { MentorBoardListType, MentorHotBoardListType } from '@/types/mentor';
+import {
+  MentorBoardListType,
+  MentorBoardParamsType,
+  MentorHotBoardListType,
+} from '@/types/mentor';
 import { useEffect, useState } from 'react';
 import * as S from './styled';
 import { useRecoilValue } from 'recoil';
@@ -11,9 +15,15 @@ const PopularMentorBoardList = () => {
   const filterCategory = useRecoilValue(CategoryFilterAtom);
 
   const getRandomMentorBoardApi = async () => {
-    const response = await MENTOR.hotMentorBoard({
+    const temp: MentorBoardParamsType = {
       categoryId: filterCategory,
-    });
+      loadOnlyPopular: true,
+      orderField: 'id',
+      sortOrder: 'DESC',
+      page: 1,
+      pageSize: 5,
+    };
+    const response = await MENTOR.MentorBoardPagination(temp);
     setHotData(response.mentorBoardForHotPostsItemDto);
   };
 

--- a/src/components/organisms/mentor-board/RandomMentorBaord.tsx
+++ b/src/components/organisms/mentor-board/RandomMentorBaord.tsx
@@ -1,18 +1,28 @@
 import MENTOR from '@/apis/mentor';
 import MentorBoardCard from '@/components/molecules/mentor-board-elements/MentorBoardCard';
-import { MentorBoardListType } from '@/types/mentor';
+import { MentorBoardListType, MentorBoardParamsType } from '@/types/mentor';
 import { useEffect, useState } from 'react';
 import * as S from './styled';
 import { useRecoilValue } from 'recoil';
 import { CategoryFilterAtom } from '@/recoil/atoms/CategorySelectAtom';
 
 const RandomMentorBoard = () => {
-  const [getRandomData, setRandomData] = useState<MentorBoardListType[]>([]);
+  const [getRandomData, setRandomData] = useState<
+    MentorBoardListType['mentorBoardForHotPostsItemDto']
+  >([]);
   const filterCategory = useRecoilValue(CategoryFilterAtom);
 
   const getRandomMentorBoardApi = async () => {
-    const response = await MENTOR.randomMentorBoard(filterCategory);
-    setRandomData(response);
+    const temp: MentorBoardParamsType = {
+      categoryId: filterCategory,
+      pageSize: 3,
+      loadOnlyPopular: false,
+      orderField: 'id',
+      sortOrder: 'DESC',
+      page: 1,
+    };
+    const response = await MENTOR.MentorBoardPagination(temp);
+    setRandomData(response.mentorBoardForHotPostsItemDto);
   };
 
   useEffect(() => {
@@ -33,14 +43,11 @@ const RandomMentorBoard = () => {
           category: data.categoryId,
           createdAt: data.createdAt,
           updatedAt: data.updatedAt,
-          userId: data.user.userImage.userId,
+          userId: data.userId,
           userName: data.user.name,
           userImage: data.user.userImage.imageUrl,
-          likes: data.mentorBoardLikes,
-          mentorBoardImage:
-            data.mentorBoardImages.length !== 0
-              ? data.mentorBoardImages[0].imageUrl
-              : '',
+          likes: data.likeCount,
+          mentorBoardImage: data.imageUrl !== null ? data.imageUrl : '',
         };
         return (
           <S.RandomMentorWrapper key={data.id}>

--- a/src/types/help.d.ts
+++ b/src/types/help.d.ts
@@ -1,11 +1,14 @@
-/** 도와주세요 게시글 불러오는 API타입 */
-export type HelpListApiType = {
+export type PaginationType<T> = {
   totalCount: number;
   currentPage: number;
   pageSize: number;
   nextPage: number;
   hasNext: boolean;
   lastPage: number;
+} & T;
+
+/** 도와주세요 게시글 불러오는 API타입 */
+export type HelpListApiType = PaginationType<{
   helpMeBoardWithUserAndImagesItemDto: {
     id: number;
     userId: number;
@@ -23,14 +26,58 @@ export type HelpListApiType = {
     };
     imageUrl: string;
   }[];
-};
+}>;
 
-/**helpListAPi요청을 위한 params type */
-export type HelpListParamsType = {
+/**도와줄게요 댓글 api타입 */
+export type HelpCommentListApiType = PaginationType<{
+  helpYouCommentWithUserAndUserImagesItemDto: {
+    id: number;
+    userId: number;
+    helpMeBoardId: number;
+    createdAt: string;
+    isAuthor: boolean;
+    user: {
+      name: string;
+      userImage: {
+        imageUrl: string;
+      };
+      rank: number;
+      activityCategory: number;
+      userIntro: {
+        shortIntro: string;
+        career: string;
+      };
+    };
+  }[];
+}>;
+
+/**도와줄게요 댓글 api타입 */
+export type HelpCommentType = PaginationType<{
+  helpYouCommentWithUserAndUserImagesItemDto: {
+    id: number;
+    userId: number;
+    helpMeBoardId: number;
+    createdAt: string;
+    isAuthor: boolean;
+    user: {
+      name: string;
+      userImage: {
+        imageUrl: string;
+      };
+      rank: number;
+      activityCategory: number;
+      userIntro: {
+        shortIntro: string;
+        career: string;
+      };
+    };
+  };
+}>;
+
+/**파아미터로 넘기는 타입 */
+export type ParamsType<T> = {
   page?: number;
   pageSize?: number;
-  categoryId: number;
-  loadOnlyPullingUp: boolean;
   orderField:
     | 'id'
     | 'userId'
@@ -41,7 +88,18 @@ export type HelpListParamsType = {
     | 'categoryId'
     | 'pullingUp';
   sortOrder: 'DESC' | 'ASC';
-};
+} & T;
+
+/**helpListAPi요청을 위한 params type */
+export type HelpListParamsType = ParamsType<{
+  categoryId: number;
+  loadOnlyPullingUp: boolean;
+}>;
+
+/**helpCommentApi요청을 위한 params type */
+export type HelpCommentParamsType = ParamsType<{
+  helpBoardId: number;
+}>;
 
 /** 도와주세요 카드형식 타입 */
 export interface HelpListType {
@@ -136,16 +194,3 @@ export type PullingUpType = {
 export interface BoardIdType {
   id: number;
 }
-
-export type HelpCommentType = {
-  id: number;
-  content: string;
-  commentOwner: boolean;
-  user: {
-    categoryId: number;
-    imageUrl: string;
-    name: string;
-    userId: number;
-    rank: number;
-  };
-};

--- a/src/types/help.d.ts
+++ b/src/types/help.d.ts
@@ -1,25 +1,46 @@
 /** 도와주세요 게시글 불러오는 API타입 */
 export type HelpListApiType = {
-  data: {
+  totalCount: number;
+  currentPage: number;
+  pageSize: number;
+  nextPage: number;
+  hasNext: boolean;
+  lastPage: number;
+  helpMeBoardWithUserAndImagesItemDto: {
     id: number;
-    body: string;
+    userId: number;
     head: string;
-    category: number;
-    createAt: string;
-    updateAt: string;
-    helpMeBoardImages: {
-      id: number;
-      imageUrl: string;
-    }[];
+    body: string;
+    createdAt: string;
+    updatedAt: string;
+    pullingUp: string | null;
+    categoryId: number;
     user: {
       name: string;
       userImage: {
-        id: number;
         imageUrl: string;
-        userId: 33;
       };
     };
+    imageUrl: string;
   }[];
+};
+
+/**helpListAPi요청을 위한 params type */
+export type HelpListParamsType = {
+  page?: number;
+  pageSize?: number;
+  categoryId: number;
+  loadOnlyPullingUp: boolean;
+  orderField:
+    | 'id'
+    | 'userId'
+    | 'head'
+    | 'body'
+    | 'createdAt'
+    | 'updatedAt'
+    | 'categoryId'
+    | 'pullingUp';
+  sortOrder: 'DESC' | 'ASC';
 };
 
 /** 도와주세요 카드형식 타입 */

--- a/src/types/mentor.d.ts
+++ b/src/types/mentor.d.ts
@@ -1,3 +1,5 @@
+import { PaginationType, ParamsType } from './help';
+
 /**멘토 게시판 생성 api 타입 */
 export type CreateMentorBoardType = {
   head: string;
@@ -6,30 +8,31 @@ export type CreateMentorBoardType = {
 };
 
 /**멘토 게시글 리스트 불러오는 api 타입
- * lik : number [좋아요 수 추가 예정 ]
  */
-export type MentorBoardListType = {
-  id: number;
-  head: string;
-  body: string;
-  categoryId: number;
-  createdAt: string;
-  updatedAt: string;
-  user: {
-    name: string;
-    userImage: {
-      userId: number;
-      id: number;
-      imageUrl: string;
-    };
-  };
-  mentorBoardImages: {
+export type MentorBoardListType = PaginationType<{
+  mentorBoardForHotPostsItemDto: {
     id: number;
-    boardId: number;
+    userId: number;
+    head: string;
+    body: string;
+    createdAt: string;
+    updatedAt: string;
+    categoryId: number;
+    user: {
+      name: string;
+      userImage: {
+        imageUrl: string;
+      };
+    };
     imageUrl: string;
+    likeCount: number;
   }[];
-  mentorBoardLikes: number;
-};
+}>;
+
+export type MentorBoardParamsType = ParamsType<{
+  categoryId: number;
+  loadOnlyPopular: boolean;
+}>;
 
 /**멘토게시판 카트형식의 타입 */
 export interface MentorBoardCardType {


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
백엔드 쪽에서 비호형이 기존에 페이지 네이션 api 두 개로 쪼개져 있던걸 하나로 합치는 작업을 진행했고, 저도 그에 맞게 기존에 두 개로 나눠져 있던 pagination을 하나로 만들었습니다. 

<!-- 추가예정 내용 (있다면 필수)-->
### Schedule
백엔드에서 내려주는 데이터 값이랑 스웨거랑 조금 다른 부분이 있고, filter가 제대로 작동 안하는 버그가 있어서 내일 아마 이야기 해보고 수정할 예정입니다.

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer
기존에 page를 먼저 받는 api 호출 후 -> 해당 page를 가지고 api요청 후 프론트 단에서 reverse시켜서 페이지 네이션을 진행했다면, 
바뀐 로직은 백엔드에서 하나의 api로 다 내려주고, 백엔드에서 프론트로 넘어오면서 역정렬된 값을 보내주는 형식으로 바뀌었습니다.
전달하는 params값이 늘어났기 때문에 스웨거 확인 잘 하시고 작업하시면 될 것 같습니다.
```chat```쪽 로직 봤는데, 제가 기존에 했던거랑 동일하게 하셔서, 백엔드에 api수정 요청하고, 그냥 제가 만든거 보고 참고하시면 될 것 같습니다.

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#129 해당 이슈 참고하셔서 어떤 부분이 api 변경되었는지 확인하시면 될 것 같습니다.