### PR TITLE
멘토 수정

### DIFF
--- a/src/components/molecules/mentor-board-elements/MentorBoardCard.tsx
+++ b/src/components/molecules/mentor-board-elements/MentorBoardCard.tsx
@@ -32,15 +32,12 @@ const MentorBoardCard = (props: MentorBoardCardType) => {
   };
   /**유저페이지로 라우트 */
   const handleRouteUser = () => {
-    router.push(
-      {
-        pathname: `/userpage/${props.userId}`,
-        query: {
-          id: props.userId,
-        },
+    router.push({
+      pathname: `/mentor/unit/${props.userId}`,
+      query: {
+        id: props.userId,
       },
-      `/userpage/${props.userId}`,
-    );
+    });
   };
 
   const foundCategory = categoryList.find(

--- a/src/components/molecules/mentor-elements/MentorCard.tsx
+++ b/src/components/molecules/mentor-elements/MentorCard.tsx
@@ -8,7 +8,6 @@ import {
 import { MentorCardType } from '@/types/mentor';
 
 const MentorCard = (props: MentorCardType) => {
-  console.log(props);
   return (
     <LinkBox
       color="#fff"

--- a/src/components/molecules/mentor-review-elements/MentorReviewElements.tsx
+++ b/src/components/molecules/mentor-review-elements/MentorReviewElements.tsx
@@ -3,6 +3,8 @@ import { ReviewProprType } from '@/types/review';
 import { useEffect, useState } from 'react';
 import * as S from './styled';
 import Image from 'next/image';
+import Link from 'next/link';
+import { LinkBox } from '@/components/common/globalStyled/styled';
 
 const MentorReviewElements = (props: ReviewProprType) => {
   const [getRank, setRank] = useState({
@@ -37,14 +39,22 @@ const MentorReviewElements = (props: ReviewProprType) => {
           <div>{getRank.name}</div>
           <div>{props.rank}점</div>
         </S.RankBox>
-        <S.UserInfoBox>
-          <div>{props.name}</div>
-          <div>
-            <div>{props.customCategory}</div>
-            <div>{props.career}</div>
-            <div>{props.shortIntro}</div>
-          </div>
-        </S.UserInfoBox>
+        <LinkBox
+          href={{
+            pathname: `/userpage/${props.menteeId}`,
+            query: {
+              id: props.id,
+            },
+          }}>
+          <S.UserInfoBox>
+            <div>{props.name}</div>
+            <div>
+              <div>{props.customCategory}</div>
+              <div>{props.career}</div>
+              <div>{props.shortIntro}</div>
+            </div>
+          </S.UserInfoBox>
+        </LinkBox>
         <S.ReviewTextBox>
           <div>{props.createdAt.slice(0, 10)}</div>
           <div>{props.review}</div>

--- a/src/components/molecules/mentor-review-elements/styled.tsx
+++ b/src/components/molecules/mentor-review-elements/styled.tsx
@@ -25,6 +25,7 @@ export const RankBox = styled.div`
 
 export const UserInfoBox = styled.div`
   & > :nth-child(1) {
+    color: #000;
     font-size: 20px;
     font-weight: bold;
     padding-left: 10px;

--- a/src/components/organisms/mentor-board/PopularMentorBoardList.tsx
+++ b/src/components/organisms/mentor-board/PopularMentorBoardList.tsx
@@ -35,26 +35,30 @@ const PopularMentorBoardList = () => {
 
   return (
     <S.MentoBoardCardContainer>
-      {getHotData.map((data) => {
-        const temp = {
-          id: data.id,
-          head: data.head,
-          body: data.body,
-          category: data.categoryId,
-          createdAt: data.createdAt,
-          updatedAt: data.updatedAt,
-          userId: data.userId,
-          userName: data.user.name,
-          userImage: data.user.userImage.imageUrl,
-          mentorBoardImage: data.imageUrl,
-          likes: data.likeCount,
-        };
-        return (
-          <S.MentorBoardCardWrapper key={data.id}>
-            <MentorBoardCard {...temp} />
-          </S.MentorBoardCardWrapper>
-        );
-      })}
+      {getHotData ? (
+        getHotData.map((data) => {
+          const temp = {
+            id: data.id,
+            head: data.head,
+            body: data.body,
+            category: data.categoryId,
+            createdAt: data.createdAt,
+            updatedAt: data.updatedAt,
+            userId: data.userId,
+            userName: data.user.name,
+            userImage: data.user.userImage.imageUrl,
+            mentorBoardImage: data.imageUrl,
+            likes: data.likeCount,
+          };
+          return (
+            <S.MentorBoardCardWrapper key={data.id}>
+              <MentorBoardCard {...temp} />
+            </S.MentorBoardCardWrapper>
+          );
+        })
+      ) : (
+        <div style={{ color: '#000' }}>없음</div>
+      )}
     </S.MentoBoardCardContainer>
   );
 };

--- a/src/components/organisms/mentor/MentorList.tsx
+++ b/src/components/organisms/mentor/MentorList.tsx
@@ -88,8 +88,6 @@ const MentorList = () => {
     }
   }, []);
 
-  console.log(getMentorData);
-
   const handleRouteChange = useCallback((e: any) => {
     sessionStorage.setItem(
       `__next_scroll_back`,

--- a/src/components/organisms/mentor/PopularMentor.tsx
+++ b/src/components/organisms/mentor/PopularMentor.tsx
@@ -27,8 +27,6 @@ const PopularMentorList = () => {
     getPopularMentorApi();
   }, []);
 
-  console.log(getPopData);
-
   const handleRouteChange = useCallback((e: any) => {
     sessionStorage.setItem(
       `__next_scroll_back`,
@@ -60,23 +58,27 @@ const PopularMentorList = () => {
 
   return (
     <S.MentoCardContainer>
-      {getPopData.map((data) => {
-        const temp = {
-          userId: data.userId,
-          name: data.name,
-          activityCategoryId: data.activityCategoryId,
-          introduce: data.introduce,
-          career: data.career,
-          mainField: data.mainField,
-          rank: data.rank,
-          reviewCount: data.reviewCount,
-        };
-        return (
-          <S.MentorCardWrapper key={data.userId}>
-            <PopularMentorCard {...temp} />
-          </S.MentorCardWrapper>
-        );
-      })}
+      {getPopData.length !== 0 ? (
+        getPopData.map((data) => {
+          const temp = {
+            userId: data.userId,
+            name: data.name,
+            activityCategoryId: data.activityCategoryId,
+            introduce: data.introduce,
+            career: data.career,
+            mainField: data.mainField,
+            rank: data.rank,
+            reviewCount: data.reviewCount,
+          };
+          return (
+            <S.MentorCardWrapper key={data.userId}>
+              <PopularMentorCard {...temp} />
+            </S.MentorCardWrapper>
+          );
+        })
+      ) : (
+        <div style={{ color: '#000' }}>인기 멘토가 없습니다.</div>
+      )}
     </S.MentoCardContainer>
   );
 };

--- a/src/components/templates/mentor-template/MentorUnitTemplate.tsx
+++ b/src/components/templates/mentor-template/MentorUnitTemplate.tsx
@@ -1,13 +1,8 @@
-import {
-  ButtonBox,
-  ContainerWrapper,
-  TextBox,
-} from '@/components/common/globalStyled/styled';
+import { ContainerWrapper } from '@/components/common/globalStyled/styled';
 import MainPageHeader from '@/components/common/header/MainPageHeader';
 import MentorUnit from '@/components/organisms/mentor/MentorUnit';
 import { useRouter } from 'next/router';
 import * as S from './styled';
-import Image from 'next/image';
 import MentorReview from '@/components/organisms/mentor/MentorReview';
 
 const MentorUnitTemplate = () => {
@@ -25,6 +20,7 @@ const MentorUnitTemplate = () => {
           <img
             src="https://menbosha-s3.s3.ap-northeast-2.amazonaws.com/public/prevBtn.svg"
             alt="이전버튼"
+            onClick={handleBack}
           />
         </S.MentorPageTitleContainer>
         <div>

--- a/src/components/templates/mentor-template/styled.ts
+++ b/src/components/templates/mentor-template/styled.ts
@@ -99,7 +99,6 @@ export const ContentContainer = styled.div`
 export const MentorReviewWrapper = styled.div`
   display: flex;
   width: 65%;
-  border: 2px solid #0ff;
   > :nth-child(1) {
     width: 180px;
     @media only all and (max-width: 1600px) {
@@ -126,5 +125,6 @@ export const MentorPageTitleContainer = styled.div`
   }
   & > :nth-child(2) {
     width: 100%;
+    cursor: pointer;
   }
 `;

--- a/src/components/templates/userpage-template/UserpageTemplate.tsx
+++ b/src/components/templates/userpage-template/UserpageTemplate.tsx
@@ -2,16 +2,40 @@ import { ContainerWrapper } from '@/components/common/globalStyled/styled';
 import MainPageHeader from '@/components/common/header/MainPageHeader';
 import MentorUnit from '@/components/organisms/mentor/MentorUnit';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import * as S from './styled';
+import MentorReview from '@/components/organisms/mentor/MentorReview';
 
 const UserpageTemplate = () => {
   const router = useRouter();
 
+  const handleBack = () => {
+    router.back();
+  };
+
   return (
     <div>
-      <MainPageHeader />
       <ContainerWrapper>
-        {router.isReady && <MentorUnit id={Number(router.query.id)} />}
+        <MainPageHeader />
+        <S.ContentContainer>
+          <S.MentorPageTitleContainer>
+            <div>멘토 프로필</div>
+            <img
+              src="https://menbosha-s3.s3.ap-northeast-2.amazonaws.com/public/prevBtn.svg"
+              alt="이전버튼"
+              onClick={handleBack}
+            />
+          </S.MentorPageTitleContainer>
+          <div>
+            {router.isReady && <MentorUnit id={Number(router.query.id)} />}
+          </div>
+        </S.ContentContainer>
+        <S.MentorReviewWrapper>
+          <div></div>
+          <S.MentorReviewContainer>
+            <div>후기</div>
+            {router.isReady && <MentorReview id={Number(router.query.id)} />}
+          </S.MentorReviewContainer>
+        </S.MentorReviewWrapper>
       </ContainerWrapper>
     </div>
   );

--- a/src/components/templates/userpage-template/styled.ts
+++ b/src/components/templates/userpage-template/styled.ts
@@ -1,0 +1,52 @@
+import styled from 'styled-components';
+
+export const ContentContainer = styled.div`
+  display: flex;
+  width: 65%;
+  margin: 100px 50px 100px 0px;
+  > :nth-child(1) {
+    font-size: 64px;
+    font-weight: bold;
+    color: #ff772b;
+    width: 180px;
+  }
+  > :nth-child(2) {
+    width: 90%;
+    display: flex;
+    justify-content: center;
+  }
+`;
+
+/**page title */
+export const MentorPageTitleContainer = styled.div`
+  & > :nth-child(1) {
+    @media only all and (max-width: 1700px) {
+      font-size: 25px;
+    }
+  }
+  & > :nth-child(2) {
+    width: 100%;
+    cursor: pointer;
+  }
+`;
+
+/**멘토 리뷰 */
+export const MentorReviewWrapper = styled.div`
+  display: flex;
+  width: 65%;
+  > :nth-child(1) {
+    width: 180px;
+    @media only all and (max-width: 1600px) {
+      display: none;
+    }
+  }
+`;
+
+export const MentorReviewContainer = styled.div`
+  width: 100%;
+  & > :nth-child(1) {
+    font-size: 20px;
+    font-weight: bold;
+    color: #ff772b;
+  }
+`;


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
유저페이지에서 라우팅을 진행하는데 뭔가 이상해서, 수정하다가 보니깐 user에 대한 정보 보여준는 페이지가 두 개 더라구요
```mentor/unit/[id]``` 랑 ```userpage/[id]``` 그래서 하나로 만들려고 봤더니, 이게 페이지가 넘어갈 때 새롭게 페이지를 렌더링 시켜야 하는데, 렌더링을 안시켜서 이 문제를 좀 잡아야 할 것 같습니다. 근데 이건 우선 다른거 할 일이 있어서 나중에 할 예정입니다. 이슈에 남겨놓을게요.

나머지는 자잘한 퍼블리싱이랑, 그냥 console.log 지운거라서 참고하시면 될 것 같습니당.