### PR TITLE
deploy(#152) docker-compose를 통한 restart

### DIFF
--- a/.github/workflows/ma6-menbosha.yml
+++ b/.github/workflows/ma6-menbosha.yml
@@ -64,6 +64,6 @@ jobs:
           docker rmi ${{ secrets.DOCKER_IMAGE_NAME }}:latest
           docker pull ${{ secrets.DOCKER_IMAGE_NAME }}:latest
 
-      - name: Restart a container in Docker Compose
+      - name: Restart the specific service in Docker Compose
         run: |
-          docker-compose restart ${{ secrets.DOCKER_SERVICES_NAME }}
+          docker-compose up -d ${{ secrets.DOCKER_SERVICES_NAME }}


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
.env를 workflow파일에서 읽는 것이 아닌  docker-compose를 통해 관리하기 위하여
compose의 하나의 services_name만  줘서 재시작.

이 pr이 올라가고 나면, https와 함께 이미지 교체가 현재 코드 이미지만 교체되는 형식으로 변경됩니다.
백엔드 서버에서 현재 쓰고있는 이미지가 코드이미지, reids, nginx-certbot 이렇게 3개인데,
코드 이미지만 변경되도록 설정하였고 잘 적용된 것을 확인하였습니다.

<!-- 추가예정 내용 (있다면 필수)-->
### Schedule

<!-- 추가된 전역관리 내용 (있다면 필수) -->
### Global Style, Recoil, Hook

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#152 