### PR TITLE
deploy(#152) action main으로 변경

### DIFF
--- a/.github/workflows/ma6-menbosha.yml
+++ b/.github/workflows/ma6-menbosha.yml
@@ -2,7 +2,7 @@ name: ma6-menbosha-front
 on:
   push:
     branches:
-      - develop
+      - main
     paths-ignore:
       - 'README.md'
       - 'LICENSE'


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description

github action 도는 브렌치 위치 develop -> main으로 변경되었습니다.
@CBWDG , @zzzRYT 지금 certbot설정 잘 돌아가는거 확인했는데. 가장 최신 코드 main으로 버전0.1 이런식으로 한번만 올려주세요


<!-- 추가예정 내용 (있다면 필수)-->
### Schedule
혹여나, develop에서도 action이 돌아가야하거나, 서버자체를 따로 두는거 필요하시면 연락 주십쇼

<!-- 추가된 전역관리 내용 (있다면 필수) -->
### Global Style, Recoil, Hook

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer

<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#152 