### PR TITLE
모달창 스크롤 막기 

### DIFF
--- a/src/components/common/header/MainPageHeader.tsx
+++ b/src/components/common/header/MainPageHeader.tsx
@@ -9,6 +9,7 @@ import { LoginStateAtom } from '@/recoil/atoms/LoginStateAtom';
 import { useRouter } from 'next/router';
 import AUTH from '@/apis/oauth';
 import { ChatContentsAtom } from '@/recoil/atoms/ChatContentsAtom';
+import SideBarReactive from '@/components/molecules/side-bar-elements/SideBarReactive';
 
 const MainPageHeader = () => {
   const router = useRouter();
@@ -31,15 +32,15 @@ const MainPageHeader = () => {
     }
   };
 
-  useEffect(() => {
-    const provider = window.localStorage.getItem('provider');
-    provider && setProvider(provider);
-  }, []);
-
   /**사이드바 핸들러 */
   const handleSideButton = () => {
     setIsSide(!isSide);
   };
+
+  useEffect(() => {
+    const provider = window.localStorage.getItem('provider');
+    provider && setProvider(provider);
+  }, []);
 
   //스크롤시 사이드 바 닫음
   useEffect(() => {
@@ -138,79 +139,13 @@ const MainPageHeader = () => {
           )}
         </S.IconBox>
       </S.HeaderArea>
-      <S.SideArea>
-        <S.SideBarContainer isSide={isSide}>
-          <S.SideBarLogoContainer>
-            <Link
-              href={{
-                pathname: `/`,
-              }}>
-              <Image
-                src="https://menbosha-s3.s3.ap-northeast-2.amazonaws.com/public/mainpage/MainLogo.svg"
-                alt="LogoIcon"
-                width={162}
-                height={47}
-              />
-            </Link>
-            <div onClick={handleSideButton}>X</div>
-          </S.SideBarLogoContainer>
-          <S.SideBarNavigateContainer>
-            <Link href={`/mentor?filterId=1`}>
-              <span>멘토 찾기</span>
-            </Link>
-            <Link href={`/mentor/board?filterId=1`}>
-              <span>멘토 게시글</span>
-            </Link>
-            <Link href={`/help?filterId=1`}>
-              <span>도와주세요</span>
-            </Link>
-            <Link href={`/support`}>
-              <span>고객지원</span>
-            </Link>
-            {isLogin ? (
-              <div>
-                <Link
-                  href={{
-                    pathname: `chat/home`,
-                  }}>
-                  <Image
-                    src="https://menbosha-s3.s3.ap-northeast-2.amazonaws.com/public/mainpage/ChatIcon-orange.svg"
-                    alt="ChatIcon"
-                    width="24"
-                    height="24"
-                    style={{ marginRight: 30 }}
-                  />
-                </Link>
-                <Link href={{ pathname: `/mypage` }}>
-                  <Image
-                    src="https://menbosha-s3.s3.ap-northeast-2.amazonaws.com/public/mainpage/User-orange.svg"
-                    alt="UserIcon"
-                    width="24"
-                    height="24"
-                    style={{ marginRight: 30 }}
-                  />
-                </Link>
-                <Image
-                  src="https://menbosha-s3.s3.ap-northeast-2.amazonaws.com/public/mainpage/Logout.svg"
-                  alt="LogoutIcon"
-                  width="24"
-                  height="24"
-                  onClick={handleLogoutApi}
-                />
-              </div>
-            ) : (
-              <Image
-                src="https://menbosha-s3.s3.ap-northeast-2.amazonaws.com/public/mainpage/sign-inBtn.svg"
-                alt="sign-in"
-                width={24}
-                height={24}
-                onClick={handleBeforeModal}
-              />
-            )}
-          </S.SideBarNavigateContainer>
-        </S.SideBarContainer>
-        {isSide && <S.SideBarBackBg onClick={handleSideButton} />}
-      </S.SideArea>
+
+      <SideBarReactive
+        handleLogoutApi={handleLogoutApi}
+        handleSideButton={handleSideButton}
+        isSide={isSide}
+        provider={provider}
+      />
     </S.HeaderContainer>
   );
 };

--- a/src/components/common/header/styled.ts
+++ b/src/components/common/header/styled.ts
@@ -64,20 +64,6 @@ export const IconBox = styled.div`
   }
 `;
 
-//1200px 반응형
-//사이드바 영역
-export const SideArea = styled.div`
-  display: none;
-  color: #000;
-  @media only all and (max-width: 1200px) {
-    display: flex;
-    flex-direction: column;
-    position: absolute;
-    left: 0px;
-    top: 0px;
-  }
-`;
-
 //사이드바 버튼 (햄버거)
 export const SideBarButton = styled.div<{ isSide: boolean }>`
   display: none;
@@ -97,81 +83,5 @@ export const SideBarButton = styled.div<{ isSide: boolean }>`
     background-color: #ff772b;
     margin: 2px 10px;
     border-radius: 10px;
-    :nth-of-type(1) {
-      top: 0;
-      ${({ isSide }) => {
-        return css`
-          transform: ${isSide && 'translateY(20xpx) rotate(-45deg)'};
-          transform: ${isSide && 'translateY(20px) rotate(-45deg)'};
-        `;
-      }}
-    }
-    :nth-of-type(2) {
-      top: 20;
-    }
-    :nth-of-type(3) {
-      bottom: 0;
-    }
-  }
-`;
-
-//사이드바 컨테이너
-export const SideBarContainer = styled.div<{ isSide: boolean }>`
-  width: 30vw;
-  height: 100vh;
-  position: absolute;
-  transition: all 0.6s ease;
-  left: ${({ isSide }) => (isSide ? '0px' : '-30vw')};
-  background-color: #fff;
-  border-right: 2px solid #ff772b;
-  z-index: 5;
-  @media only all and (max-width: 600px) {
-    left: ${({ isSide }) => (isSide ? '0px' : '-40vw')};
-  }
-`;
-
-//사이드바 밖 영역(클릭 시 사이드바 닫힘)
-export const SideBarBackBg = styled.div`
-  width: 100vw;
-  height: 100vh;
-  position: fixed;
-  z-index: 4;
-  background-color: rgba(0, 0, 0, 0.1);
-`;
-
-export const SideBarLogoContainer = styled.div`
-  display: flex;
-  & > :nth-child(1) {
-    margin: 15px 0px 0px 15px;
-  }
-  & > :nth-child(2) {
-    margin: 20px 15px 0px auto;
-    color: #ff772b;
-  }
-  @media only all and (max-width: 600px) {
-    display: none;
-  }
-`;
-
-export const SideBarNavigateContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  margin: 50px 0px;
-  & > :nth-child(n) {
-    margin: 10px auto;
-    text-decoration: none;
-    color: #ff772b;
-    cursor: pointer;
-    &:hover {
-      font-weight: 600;
-    }
-  }
-  & > :nth-last-child(1) {
-    margin-top: 65vh;
-  }
-  @media only all and (max-height: 1000px) {
-    & > :nth-last-child(1) {
-      margin-top: 30vh;
-    }
   }
 `;

--- a/src/components/molecules/side-bar-elements/SideBarReactive.tsx
+++ b/src/components/molecules/side-bar-elements/SideBarReactive.tsx
@@ -1,0 +1,104 @@
+import Image from 'next/image';
+import * as S from './styled';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { LoginStateAtom } from '@/recoil/atoms/LoginStateAtom';
+import useModal from '@/hooks/useModal';
+import { useEffect, useState } from 'react';
+
+interface SideBarType {
+  handleLogoutApi: () => void;
+  handleSideButton: () => void;
+  isSide: boolean;
+  provider: string;
+}
+
+const SideBarReactive = ({
+  handleLogoutApi,
+  handleSideButton,
+  isSide,
+}: SideBarType) => {
+  const router = useRouter();
+  const [isLogin, setLoginState] = useRecoilState(LoginStateAtom);
+  const { isOpenModal: beforeModal, handleModal: handleBeforeModal } =
+    useModal();
+
+  return (
+    <S.SideArea>
+      <S.SideBarContainer isSide={isSide}>
+        <S.SideBarLogoContainer>
+          <Link
+            href={{
+              pathname: `/`,
+            }}>
+            <Image
+              src="https://menbosha-s3.s3.ap-northeast-2.amazonaws.com/public/mainpage/MainLogo.svg"
+              alt="LogoIcon"
+              width={162}
+              height={47}
+            />
+          </Link>
+          <div onClick={handleSideButton}>X</div>
+        </S.SideBarLogoContainer>
+        <S.SideBarNavigateContainer>
+          <Link href={`/mentor?filterId=1`}>
+            <span>멘토 찾기</span>
+          </Link>
+          <Link href={`/mentor/board?filterId=1`}>
+            <span>멘토 게시글</span>
+          </Link>
+          <Link href={`/help?filterId=1`}>
+            <span>도와주세요</span>
+          </Link>
+          <Link href={`/support`}>
+            <span>고객지원</span>
+          </Link>
+          {isLogin ? (
+            <div>
+              <Link
+                href={{
+                  pathname: `/chat/home`,
+                }}>
+                <Image
+                  src="https://menbosha-s3.s3.ap-northeast-2.amazonaws.com/public/mainpage/ChatIcon-orange.svg"
+                  alt="ChatIcon"
+                  width="24"
+                  height="24"
+                  style={{ marginRight: 30 }}
+                />
+              </Link>
+              <Link href={{ pathname: `/mypage` }}>
+                <Image
+                  src="https://menbosha-s3.s3.ap-northeast-2.amazonaws.com/public/mainpage/User-orange.svg"
+                  alt="UserIcon"
+                  width="24"
+                  height="24"
+                  style={{ marginRight: 30 }}
+                />
+              </Link>
+              <Image
+                src="https://menbosha-s3.s3.ap-northeast-2.amazonaws.com/public/mainpage/Logout.svg"
+                alt="LogoutIcon"
+                width="24"
+                height="24"
+                onClick={handleLogoutApi}
+              />
+            </div>
+          ) : (
+            <Image
+              src="https://menbosha-s3.s3.ap-northeast-2.amazonaws.com/public/mainpage/sign-inBtn.svg"
+              alt="sign-in"
+              width={24}
+              height={24}
+              onClick={handleBeforeModal}
+            />
+          )}
+        </S.SideBarNavigateContainer>
+      </S.SideBarContainer>
+      {isSide && <S.SideBarBackBg onClick={handleSideButton} />}
+    </S.SideArea>
+  );
+};
+
+export default SideBarReactive;

--- a/src/components/molecules/side-bar-elements/styled.tsx
+++ b/src/components/molecules/side-bar-elements/styled.tsx
@@ -1,0 +1,75 @@
+import styled, { css } from 'styled-components';
+
+//사이드바 영역
+export const SideArea = styled.div`
+  display: none;
+  color: #000;
+  @media only all and (max-width: 1200px) {
+    display: flex;
+    flex-direction: column;
+    position: absolute;
+    left: 0px;
+    top: 0px;
+  }
+`;
+
+//사이드바 컨테이너
+export const SideBarContainer = styled.div<{ isSide: boolean }>`
+  width: 29vw;
+  height: 300vh;
+  position: absolute;
+  transition: all 0.6s ease;
+  left: ${({ isSide }) => (isSide ? '0px' : '-30vw')};
+  background-color: #fff;
+  border-right: 2px solid #ff772b;
+  z-index: 5;
+  @media only all and (max-width: 600px) {
+    left: ${({ isSide }) => (isSide ? '0px' : '-40vw')};
+  }
+`;
+
+//사이드바 밖 영역(클릭 시 사이드바 닫힘)
+export const SideBarBackBg = styled.div`
+  width: 100vw;
+  height: 100vh;
+  position: fixed;
+  z-index: 4;
+  background-color: rgba(0, 0, 0, 0.1);
+`;
+
+export const SideBarLogoContainer = styled.div`
+  display: flex;
+  & > :nth-child(1) {
+    margin: 15px 0px 0px 15px;
+  }
+  & > :nth-child(2) {
+    margin: 20px 15px 0px auto;
+    color: #ff772b;
+  }
+  @media only all and (max-width: 600px) {
+    display: none;
+  }
+`;
+
+export const SideBarNavigateContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin: 50px 0px;
+  & > :nth-child(n) {
+    margin: 10px auto;
+    text-decoration: none;
+    color: #ff772b;
+    cursor: pointer;
+    &:hover {
+      font-weight: 600;
+    }
+  }
+  & > :nth-last-child(1) {
+    margin-top: 65vh;
+  }
+  @media only all and (max-height: 1000px) {
+    & > :nth-last-child(1) {
+      margin-top: 30vh;
+    }
+  }
+`;

--- a/src/components/organisms/auth/LoginModal.tsx
+++ b/src/components/organisms/auth/LoginModal.tsx
@@ -13,6 +13,34 @@ interface ModalType {
 }
 
 const LoginModal = ({ show, hide }: ModalType) => {
+  const preventScroll = () => {
+    const currentScrollY = window.scrollY;
+    document.body.style.position = 'fixed';
+    document.body.style.width = '100%';
+    document.body.style.top = `-${currentScrollY}px`; // 현재 스크롤 위치
+    document.body.style.overflowY = 'scroll';
+    return currentScrollY;
+  };
+
+  /**
+   * 스크롤을 허용하고, 스크롤 방지 함수에서 반환된 위치로 이동한다.
+   * @param prevScrollY 스크롤 방지 함수에서 반환된 스크롤 위치
+   */
+  const allowScroll = (prevScrollY: number) => {
+    document.body.style.position = '';
+    document.body.style.width = '';
+    document.body.style.top = '';
+    document.body.style.overflowY = '';
+    window.scrollTo(0, prevScrollY);
+  };
+
+  useEffect(() => {
+    const prevScrollY = preventScroll();
+    return () => {
+      allowScroll(prevScrollY);
+    };
+  }, []);
+
   useEffect(() => {
     const storage = globalThis?.sessionStorage;
     if (!storage) {


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
- 모달이 켜지면, window객체를 이용해서 style에 접근해서 body태그의 스크롤을 못 움직이게 했습니다. 밑에 레퍼런스가 있지만, 스크롤을 숨겨버리는 방식이 아니라, 메인페이지의 UI를 유지시키면서 스크롤만 안되게 하는 로직이 있어서 그걸 사용했습니다.
- 반응형으로 나오는 사이드바 부분도, 켜졌을 때 스크롤이 안되도록 막으려했는데, 그 부분은 모달로작성한게 아니라, 컴포넌트를 화면 밖으로 숨겼다가 가지고 오는 방식이라서 그냥 길이만 늘려서 자연스럽게 만들어놨습니다. 

<!-- 추가예정 내용 (있다면 필수)-->
### Schedule
모달창 뽝 하고 켜지는게 아니라, `transition`이나 `keyframe`을 사용해서 자연스럽게 나타나게 하려고합니다.


<!-- 참고한 레퍼런스 링크 (선택) -->
### Reference Link
[참고블로그](https://velog.io/@sunohvoiin/ReactCSS-%EB%AA%A8%EB%8B%AC%EC%B0%BD%EC%9D%B4-%EC%97%B4%EB%A0%A4%EC%9E%88%EC%9D%84-%EB%95%8C-body-%EC%8A%A4%ED%81%AC%EB%A1%A4-%EB%B0%A9%EC%A7%80%ED%95%98%EA%B8%B0)

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#242 
