### PR TITLE
automatic renewal of ssl

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -57,14 +57,24 @@ ENV PORT 80
 
 CMD ["node", "server.js"]
 
+#######################################- 여기서부터 ngninx dockerfile -##########################################
 # #nginx 이미지 사용
 # FROM nginx:latest
 
-# #nignx와 certbot 설치
-# RUN apt-get update && apt-get install -y certbot python3-certbot-nginx
+# #nignx와 certbot 설치 -(+인증서 갱신을 위한 cron)
+# RUN apt-get update && apt-get install -y certbot python3-certbot-nginx cron
 
 # #nginx.conf(설정파일 복사)
 # COPY nginx.conf /etc/nginx/nginx.conf
+
+# #SSL 인증서 갱신을 위한 cron 스크립트 복사
+# COPY renew_ssl_cert.sh /renew_ssl_cert.sh
+
+# #스크립트 권한 부여
+# RUN chmod +x /renew_ssl_cert.sh
+
+# #cron 작업 추가
+# RUN echo "0 0 1 * * root /renew_ssl_cert.sh" >> /etc/crontab
 
 # #port
 # EXPOSE 80
@@ -76,3 +86,4 @@ CMD ["node", "server.js"]
 
 # #컨테이너가 실행될 때 entrypoint.sh 실행
 # CMD ["/entrypoint.sh"]
+

--- a/renew_ssl_cert.sh
+++ b/renew_ssl_cert.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Certbot을 사용하여 SSL 인증서 갱신
+certbot renew --quiet --nginx


### PR DESCRIPTION
<!-- 내용 (필수) -->
### Description
dockerfile에 빌드 자체를 cron이 같이 설치되게 합니다.
renew_ssl_cert.sh 라는 스크립트 파일을 같이 빌드하여,
dockerfile 자체에서, 즉 컨테이너 자체에서 매달 1일 00시에 자동으로 스크립트 파일을 실행시킵니다.

<!-- 추가예정 내용 (있다면 필수)-->
### Schedule
만약 이 방법이 먹히지 않는다면, 컨테이너 자체를 UTC 기준 00시 초기화 하는 것 또한 생각중입니다.
테스트는 30일 백엔드 개발서버에 적용하고, 된다면 31일 프론트 베포서버, -> 4/1일 백엔드 서버에 들어올 예정입니다.

<!-- 리뷰어가 리뷰하기전 알면 좋을 내용 (선택) -->
### To Reviewer

<!-- 관련된 이슈 링크 (선택) -->
### Related Issue Link
#249 